### PR TITLE
Add project description to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 gun [![Build Status](https://travis-ci.org/amark/gun.svg?branch=master)](https://travis-ci.org/amark/gun)
 ===
 
+A distributed, embedded, graph database engine.
+
 ## Getting Started
 
 If you do not have [node](http://nodejs.org/) or [npm](https://www.npmjs.com/), read [this](https://github.com/amark/gun/blob/master/examples/install.sh) first.


### PR DESCRIPTION
Hi,

I scrolled past the "GitHub-Header description" and went straight for the actual README just to find no clue as to what this does :wink: 

This adds the one-liner so the README is more self-contained and easier to digest.
