### PR TITLE
Remove text shadow from website

### DIFF
--- a/index.html
+++ b/index.html
@@ -625,7 +625,6 @@ ref.on(function(data){
 		background: rgba(100%,100%,100%,.6);
 		font-family: Arial;
 		font-size: 18pt;
-		text-shadow: 0px 0px 7px #DDD;
 		line-height: 20pt;
 	}
 	#main p {


### PR DESCRIPTION
the text shadow makes the text look like it's being rendered as a low quality JPG or somethin'. it's substantially more readable w.o. the shadow imo.