### PR TITLE
Add basic compatibility with browserify and webpack

### DIFF
--- a/gun.js
+++ b/gun.js
@@ -980,6 +980,9 @@
 	}({}));
 	if(typeof window !== "undefined"){
 		window.Gun = Gun;
+		if(typeof module !== 'undefined' && module.exports){
+			module.exports = Gun;
+		}
 	} else {
 		module.exports = Gun;
 	}

--- a/gun.js
+++ b/gun.js
@@ -980,10 +980,8 @@
 	}({}));
 	if(typeof window !== "undefined"){
 		window.Gun = Gun;
-		if(typeof module !== 'undefined' && module.exports){
-			module.exports = Gun;
-		}
-	} else {
+	}
+	if(typeof module !== 'undefined' && module.exports){
 		module.exports = Gun;
 	}
 	var root = this || {}; // safe for window, global, root, and 'use strict'.


### PR DESCRIPTION
On the compile step, both window and module are defined. Gun prevents module exports by detecting the environment and tacking Gun onto the window object. This addition will check to see if it's a dual environment (like browserify or electron) and export to both window and module, preventing errors in your build step.

Fixes #133