### PR TITLE
Remove unused "formidable" dependency in wsp.js

### DIFF
--- a/lib/wsp.js
+++ b/lib/wsp.js
@@ -1,6 +1,5 @@
 ;(function(wsp){
 	var Gun = require('../gun')
-	, formidable = require('formidable')
 	, ws = require('ws').Server
 	, http = require('./http')
 	, url = require('url');


### PR DESCRIPTION
Formidable is only used in http.js, and although it is required by wsp.js, it's never used.