### PR TITLE
Fix thrown error in `.set`

### DIFF
--- a/gun.js
+++ b/gun.js
@@ -976,6 +976,7 @@
 
 		Gun.chain.set = function(item, cb, opt){
 			var gun = this, ctx = {}, chain;
+			cb = cb || function(){};
 			if(!Gun.is(item)){ return cb.call(gun, {err: Gun.log('Set only supports node references currently!')}), gun } // TODO: Bug? Should we return not gun on error?
 			(ctx.chain = item.chain()).back = gun;
 			ctx.chain._ = item._;


### PR DESCRIPTION
When passed a primitive value but not a callback, `.set` will try to
invoke the callback with the error data, except since it's undefined, it
throws. I've added a line that prevents that error, allowing execution
to continue with the developer warning.