### PR TITLE
Readme goodness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# gun [![NPM downloads](https://img.shields.io/npm/dm/gun.svg?style=flat)](https://npmjs.org/package/gun) [![Build Status](https://travis-ci.org/amark/gun.svg?branch=master)](https://travis-ci.org/amark/gun) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/amark/gun?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+# [![gun](https://cldup.com/-Cq2s4HgZN.png)](http://gundb.io/)
+
+[![npm](https://img.shields.io/npm/dm/gun.svg)](https://www.npmjs.com/package/gun)
+[![Travis](https://img.shields.io/travis/amark/gun/master.svg)](https://travis-ci.org/amark/gun)
+[![Gitter](https://img.shields.io/gitter/room/amark/gun.js.svg)](https://gitter.im/amark/gun)
 
 GUN is a realtime, distributed, offline-first, graph database engine. Lightweight and powerful, at just **~9KB** gzipped.
 


### PR DESCRIPTION
New logo, new badges.

I turned our name into a nifty logo (falling back to our name) that links to gundb.io, and moved all badges to shields.io for a consistent look. The logo has been resized to occupy 40% of the readme width. The image is hosted on CloudUp under the company profile. I'm using them because I cheated and looked at what express.js does.