### PR TITLE
Binding module scope for ES6/Babel compatibility

### DIFF
--- a/gun.js
+++ b/gun.js
@@ -1132,7 +1132,7 @@
 	};
 	console.debug = function(i, s){ return (Gun.log.debug && i === Gun.log.debug && Gun.log.debug++) && root.console.log.apply(root.console, arguments), s };
 	Gun.log.count = function(s){ return Gun.log.count[s] = Gun.log.count[s] || 0, Gun.log.count[s]++ }
-}());
+}.bind(this || module)());
 
 
 ;(function(Tab){
@@ -1147,7 +1147,7 @@
 		s.del = function(key){ return store.removeItem(key) }
 		var store = this.localStorage || {setItem: function(){}, removeItem: function(){}, getItem: function(){}};
 		exports.store = s;
-	}(Tab));
+	}.bind(this || module)(Tab));
 
 	Gun.on('opt').event(function(gun, opt){
 		opt = opt || {};
@@ -1432,4 +1432,4 @@
 		}
 		return r;
 	}());
-}({}));
+}.bind(this || module)({}));


### PR DESCRIPTION
When transpiling the module with Babel, `this` is undefined within n ES6 module. In order to inherit the proper scope, self-executing functions now use `bind`, first using an existing `this` scope (ES5 require module or browser) or, alternatively, the `module` scope (ES6).

This has been tested within React-Native using Babel as well as Chrome.