### PR TITLE
Make `data.json` human-readable

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -25,7 +25,8 @@ Gun.on('opt').event(function(gun, opts) {
 	function writeFile(cb) {
 		if(isWriting) return queuedWrites.push(cb);
 		isWriting = true;
-		fs.writeFile(opts.file, Gun.text.ify(all), function(err) {
+		var contents = JSON.stringify(all, null, 2);
+		fs.writeFile(opts.file, contents, function(err) {
 			var batch = queuedWrites.splice(0);
 			isWriting = false;
 			cb(err);

--- a/lib/wsp.js
+++ b/lib/wsp.js
@@ -1,6 +1,5 @@
 ;(function(wsp){
 	var Gun = require('../gun')
-	, formidable = require('formidable')
 	, ws = require('ws').Server
 	, http = require('./http')
 	, url = require('url');


### PR DESCRIPTION
Since the file.js module is only for development or getting started, we shouldn't have to minify the data before persisting it. In fact, it may hurt things, since it obfuscates our data structure and makes it harder
to understand what's going on under the hood.

In this commit, I swapped `Gun.text.ify` with JSON's `stringify` and gave it a 2-space formatting option to make the data more readable.