### PR TITLE
ws error on send

### DIFF
--- a/gun.js
+++ b/gun.js
@@ -1350,7 +1350,7 @@
 					if(res.body || res.end){ delete r.ws.cbs[req.headers['ws-rid']] }
 					cb(err,res);
 				}
-				ws.send(JSON.stringify(req),function(err) {});
+				ws.send(JSON.stringify(req),function(err){})
 				return true;
 			}
 			if(ws === false){ return }

--- a/gun.js
+++ b/gun.js
@@ -1350,7 +1350,7 @@
 					if(res.body || res.end){ delete r.ws.cbs[req.headers['ws-rid']] }
 					cb(err,res);
 				}
-				ws.send(JSON.stringify(req),function(err) { // that's all })
+				ws.send(JSON.stringify(req),function(err) {});
 				return true;
 			}
 			if(ws === false){ return }

--- a/gun.js
+++ b/gun.js
@@ -1350,7 +1350,7 @@
 					if(res.body || res.end){ delete r.ws.cbs[req.headers['ws-rid']] }
 					cb(err,res);
 				}
-				ws.send(JSON.stringify(req));
+				ws.send(JSON.stringify(req),function(err) { // that's all })
 				return true;
 			}
 			if(ws === false){ return }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gun",
-  "version": "0.3.992",
+  "version": "0.3.993",
   "description": "Graph engine",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When sending through a ws socket you might get an error saying that the socket is not open.
by adding an empty callback to `ws.send`  this seems to fixe it