### PR TITLE
Add ability to stop broadcast

### DIFF
--- a/lib/wsp.js
+++ b/lib/wsp.js
@@ -17,7 +17,7 @@
 					if(msg && msg.headers){ delete msg.headers['ws-rid'] }
 					// TODO: BUG? ^ What if other peers want to ack? Do they use the ws-rid or a gun declared id?
 					try{ws.send(Gun.text.ify(msg));
-					}catch(e){} // juuuust in case. 
+					}catch(e){} // juuuust in case.
 				});
 				gun.wsp.wire(req, res);
 			});
@@ -104,7 +104,7 @@
 					Gun.obj.del(gun.wsp.msg.debounce, id);
 				});
 			},500);
-			if(id = gun.wsp.msg.debounce[id]){ 
+			if(id = gun.wsp.msg.debounce[id]){
 				return gun.wsp.msg.debounce[id] = Gun.time.is(), id;
 			}
 		};
@@ -114,7 +114,9 @@
 			// except for the ones that are listed in the message as having already been sending to.
 			// all states, implemented with GET, are replied to the source that asked for it.
 			function flow(req, res){
-				gun.wsp.on('network').emit(Gun.obj.copy(req));
+				if (!req.auth || req.headers.broadcast) {
+					gun.wsp.on('network').emit(Gun.obj.copy(req));
+				}
 				if(req.headers.rid){ return } // no need to process.
 				if(Gun.is.lex(req.body)){ return tran.get(req, res) }
 				else { return tran.put(req, res) }
@@ -159,7 +161,7 @@
 						if(opt.on && opt.on.off){ opt.on.off() }
 						return cb({headers: reply.headers, body: (err? (err.err? err : {err: err || "Unknown error."}) : null)});
 					}
-					if(Gun.obj.empty(node)){ 
+					if(Gun.obj.empty(node)){
 						if(opt.on && opt.on.off){ opt.on.off() }
 						return cb({headers: reply.headers, body: node});
 					} // we're out of stuff!
@@ -191,7 +193,7 @@
 				// This will give you much more fine-grain control over security, transactions, and what not.
 				var reply = {headers: {'Content-Type': tran.json, rid: req.headers.id, id: gun.wsp.msg()}};
 				if(!req.body){ return cb({headers: reply.headers, body: {err: "No body"}}) }
-				//Gun.log("\n\ntran.put ----------------->", req.body);					
+				//Gun.log("\n\ntran.put ----------------->", req.body);
 				if(Gun.is.graph(req.body)){
 					if(req.err = Gun.union(gun, req.body, function(err, ctx){ // TODO: BUG? Probably should give me ctx.graph
 						if(err){ return cb({headers: reply.headers, body: {err: err || "Union failed."}}) }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gun",
-  "version": "0.3.995",
+  "version": "0.3.996",
   "description": "Graph engine",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
If the gun `.wsp` callback is passed, the developer might be doing fancy auth stuff.

In this case, the default should be *not* to broadcast the data to everyone. Instead, the callback (or the client) can opt into broadcasting by setting the request header `broadcast` property to `true`.