### PR TITLE
added yarn.lock to gitignore and fixed npm start

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/*
 npm-debug.log
+yarn.lock
 *data.json
 *.db
 .idea/

--- a/examples/http.js
+++ b/examples/http.js
@@ -1,6 +1,6 @@
 var port = process.env.OPENSHIFT_NODEJS_PORT || process.env.VCAP_APP_PORT || process.env.PORT || process.argv[2] || 80;
 
-var Gun = require('gun');
+var Gun = require('../');
 var gun = Gun({ 
 	file: 'data.json',
 	s3: {


### PR DESCRIPTION
Added yarn.lock to gitignore which ensures people using yarn will not be checking in lock files.

Upon checking out the code, running npm install, and then npm start, I received an error that it could not find module `gun`:

![image](https://cloud.githubusercontent.com/assets/424694/19457706/6cb89934-947c-11e6-826b-e98e202ac28d.png)

Changing the code to require gun's package.json directory fixes the issue.