### PR TITLE
Fix /gun.js route

### DIFF
--- a/lib/wsp.js
+++ b/lib/wsp.js
@@ -34,7 +34,7 @@
 					if(msg && msg.headers){ delete msg.headers['ws-rid'] }
 					// TODO: BUG? ^ What if other peers want to ack? Do they use the ws-rid or a gun declared id?
 					try{ws.send(Gun.text.ify(msg));
-					}catch(e){} // juuuust in case. 
+					}catch(e){} // juuuust in case.
 				});
 				gun.wsp.wire(req, res);
 			}, {headers: {'ws-rid': 1, 'gun-sid': 1}});
@@ -67,7 +67,6 @@
 		gun.wsp.server = gun.wsp.server || function(req, res, next){ // http
 			next = next || function(){};
 			if(!req || !res){ return next(), false }
-			if(!req.upgrade){ return next(), false }
 			if(!req.url){ return next(), false }
 			if(!req.method){ return next(), false }
 			var msg = {};
@@ -78,6 +77,7 @@
 				res.end(gun.wsp.js = gun.wsp.js || require('fs').readFileSync(__dirname + '/../gun.js')); // gun server is caching the gun library for the client
 				return true;
 			}
+			if(!req.upgrade){ return next(), false }
 			return http(req, res, function(req, res){
 				if(!req){ return next() }
 				var stream, cb = res = require('./jsonp')(req, res);
@@ -121,7 +121,7 @@
 					Gun.obj.del(gun.wsp.msg.debounce, id);
 				});
 			},500);
-			if(id = gun.wsp.msg.debounce[id]){ 
+			if(id = gun.wsp.msg.debounce[id]){
 				return gun.wsp.msg.debounce[id] = Gun.time.is(), id;
 			}
 			gun.wsp.msg.debounce[id] = Gun.time.is();


### PR DESCRIPTION
The `wsp.server` logic was never making it to the /gun.js route. If the
browser is just sending a GET request for a the js file, it won't set
the upgrade property, and the server logic wouldn't let the request pass
if it didn't have that header.
I've simply moved the check below the file serving logic.
All the `git diff` stuff is probably due to whitespace changes.