### PR TITLE
Enable .set with node, or new soul.

### DIFF
--- a/gun.js
+++ b/gun.js
@@ -526,7 +526,13 @@
 		Gun.on.at.hash = function(at){ return (at.at && at.at.soul)? at.at.soul + (at.at.field || '') : at.soul + (at.field || '') }
 
 		Gun.on.at.copy = function(at){ return Gun.obj.del(at, 'hash'), Gun.obj.map(at, function(v,f,t){t(f,v)}) }
-		
+
+		Gun.root = function(gun) {
+			if (!Gun.is(gun)) return null;
+			if (gun.back === gun) return gun;
+			return Gun.root(gun.back);
+		};
+
 	}(Gun));
 	
 	;(function(Gun){ // Gun prototype chain methods.
@@ -1000,8 +1006,16 @@
 		}
 
 		Gun.chain.set = function(item, cb, opt){
-			var gun = this, ctx = {}, chain;
+			var gun = this, ctx = {}, chain, rel;
 			cb = cb || function(){};
+			if(Gun.is.node(item) && (rel=Gun.is.rel(item._))){
+				// Resolve set with a node
+				return gun.set(gun.get(rel), cb, opt);
+			}
+			if(typeof(item)=='object'&&!Gun.is(item)&&!Gun.is.rel(item)&&!Gun.is.lex(item)&&!Gun.is.node(item)&&!Gun.is.graph(item)){
+				// Resolve set with a new soul
+				return gun.set(Gun.root(gun).put(item), cb, opt);
+			}
 			if(!Gun.is(item)){ return cb.call(gun, {err: Gun.log('Set only supports node references currently!')}), gun } // TODO: Bug? Should we return not gun on error?
 			(ctx.chain = item.chain()).back = gun;
 			ctx.chain._ = item._;

--- a/test/common.js
+++ b/test/common.js
@@ -3757,9 +3757,18 @@ describe('Gun', function(){
 			bob.path('friends').set(alice);
 			dave.path('friends').set(alice).back.set(carl);
 
+			// Test set with new object
+			var alan = users.set({name: 'alan', birth: Math.random()}).key('person/alan');
+			alan.val(function(alan) {
+				// Test set with node
+				dave.path('friends').set(alan);
+			});
+
+
 			var team = gun.get('team/lions').put({name: "Lions"});
 			team.path('members').set(alice);
 			team.path('members').set(bob);
+			team.path('members').set(alan);
 
 			alice.path('team').put(team);
 			bob.path('team').put(team);
@@ -3771,10 +3780,14 @@ describe('Gun', function(){
 				} else
 				if('bob' === member.name){
 					done.bob = true;
-				} else {
+				} else
+				if('alan' === member.name){
+					done.alan = true;
+				} else
+				{
 					expect(member).to.not.be.ok();
 				}
-				if(done.alice && done.bob){
+				if(done.alice && done.bob && done.alan){
 					setTimeout(function(){
 						done();
 					},10);


### PR DESCRIPTION
@amark, while using `.set`, I encountered the error message: `Set only supports node references currently!`. This change aims to add a little more flexibility to `.set`.

Like `.put`, you are now able to pass a new anonymous object, or a node retrieved by a `.val`. 

I've updated the unit test to demonstrate pretty much any way you want to use `.set` will work now.

```javascript
// Test set with new object
var alan = users.set({name: 'alan', birth: Math.random()}).key('person/alan');
alan.val(function(alan) {
	// Test set with node
	dave.path('friends').set(alan);
});
// Demonstrates .set returns a node reference
team.path('members').set(alan);
```