### PR TITLE
Enable .set with node, or new soul. (0.5)

### DIFF
--- a/gun.js
+++ b/gun.js
@@ -2024,8 +2024,10 @@
 
 		;(function(){
 			Gun.chain.set = function(item, cb, opt){
-				var gun = this;
+				var gun = this, soul;
 				cb = cb || function(){};
+				if (soul = Gun.node.soul(item)) return gun.set(gun.get(soul), cb, opt);
+				if (Gun.obj.is(item) && !Gun.is(item)) return gun.set(gun._.root.put(item), cb, opt);
 				return item.val(function(node){
 					var put = {}, soul = Gun.node.soul(node);
 					if(!soul){ return cb.call(gun, {err: Gun.log('Only a node can be linked! Not "' + node + '"!')}) }

--- a/test/common.js
+++ b/test/common.js
@@ -6090,6 +6090,13 @@ describe('Gun', function(){
 			var carl = gun.put({name: 'carl', birth: Math.random()}).key('person/carl');
 			var dave = gun.put({name: 'dave', birth: Math.random()}).key('person/dave');
 
+			// Test set with new object
+			var alan = users.set({name: 'alan', birth: Math.random()}).key('person/alan');
+			alan.val(function(alan) {
+				// Test set with node
+				dave.path('friends').set(alan);
+			});
+
 			users.set(alice);
 			users.set(bob);
 			users.set(carl);
@@ -6102,6 +6109,7 @@ describe('Gun', function(){
 			var team = gun.get('team/lions').put({name: "Lions"});
 			team.path('members').set(alice);
 			team.path('members').set(bob);
+			team.path('members').set(alan); // Test set with set
 
 			alice.path('team').put(team);
 			bob.path('team').put(team);
@@ -6113,10 +6121,14 @@ describe('Gun', function(){
 				} else
 				if('bob' === member.name){
 					done.bob = true;
-				} else {
+				} else
+				if('alan' === member.name){
+					done.alan = true;
+				} else
+				{
 					expect(member).to.not.be.ok();
 				}
-				if(done.alice && done.bob){
+				if(done.alice && done.bob && done.alan){
 					setTimeout(function(){
 						done();
 					},10);


### PR DESCRIPTION
`.set` for anonymous objects, or nodes. Fixes an eror in 0.5 because `.set` assumes `item` is a gun.

Added the unit tests, but the 0.5 tests don't seem to run naturally.
