### PR TITLE
Fixed dependency versioning so Travis-CI doesn't choke on tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   },
   "homepage": "https://github.com/amark/gun#readme",
   "engines": {
-    "node": ">=0.6.6",
+    "node": ">=4.2",
     "iojs": ">=0.0.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "mocha": "^1.9.0",
-    "express": "^4.13.4",
+    "express": "^4.13.0",
     "panic-server": "^0.3.0",
     "selenium-webdriver": "^2.53.2"
   }

--- a/package.json
+++ b/package.json
@@ -49,9 +49,9 @@
     "ws": "~>1.0.1"
   },
   "devDependencies": {
-    "mocha": "~>1.9.0",
-    "express": "~>4.13.4",
-    "panic-server": "~>0.3.0",
-    "selenium-webdriver": "~>2.53.2"
+    "mocha": "^1.9.0",
+    "express": "^4.13.4",
+    "panic-server": "^0.3.0",
+    "selenium-webdriver": "^2.53.2"
   }
 }


### PR DESCRIPTION
This should only be merged if it cleans up the Travis-CI test that was failing after the on boarding fix, so, on hold, for Travis...