### PR TITLE
Allow opting out of file.json

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -6,6 +6,13 @@ var Gun = require('../gun'),
 	fs = require('fs'),
 	file = {};
 
+function isUsingFileJS (context) {
+	var gun = context.gun;
+	var opt = context.opt || gun.Back('opt') || {};
+
+	return opt.file !== false;
+}
+
 // queue writes, adapted from https://github.com/toolness/jsondown/blob/master/jsondown.js
 var isWriting = false, queuedWrites = [];
 function writeFile(path, disk, at){
@@ -24,6 +31,9 @@ function writeFile(path, disk, at){
 }
 
 Gun.on('put', function(at){
+	if (isUsingFileJS(at) === false) {
+		return;
+	}
 	var gun = at.gun, graph = at.put, opt = at.opt || {};
 	var __ = gun._.root._;
 	Gun.obj.map(graph, function(node, soul){
@@ -32,7 +42,10 @@ Gun.on('put', function(at){
 	writeFile(opt.file || file.file, file.disk, at);
 });
 Gun.on('get', function(at){
-	var gun = at.gun, lex = at.get, opt = at.opt;
+	if (isUsingFileJS(at) === false) {
+		return;
+	}
+	var gun = at.gun, lex = at.get;
 	if(!lex){return}
 	gun.Back(-1).on('in', {'@': at['#'], put: Gun.graph.node(file.disk.graph[lex['#']])});
 	//at.cb(null, file.disk.graph[lex['#']]);
@@ -43,7 +56,11 @@ Gun.on('opt', function(at){
 	if ((opts.file === false) || (opts.s3 && opts.s3.key)) {
 		return; // don't use this plugin if S3 is being used.
 	}
-	console.log("WARNING! This `file.js` module for gun is intended only for local development testing!")
+	Gun.log.once(
+		'file-warning',
+		'WARNING! This `file.js` module for gun is ' +
+		'intended only for local development testing!'
+	);
 	file.file = opts.file || file.file || 'data.json';
 	file.raw = file.raw || (fs.existsSync || require('path').existsSync)(opts.file) ? fs.readFileSync(opts.file).toString() : null;
 	file.disk = file.disk || Gun.obj.ify(file.raw || {graph: {}});


### PR DESCRIPTION
If the most recent gun options disable the file module, then it
won't try to read/write from the json. Previously it would. Also, now
you can prevent the drivers from being called by passing `{ file: false }` as the
options in `gun.put`.