### PR TITLE
Reliably check file.js options

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -7,10 +7,20 @@ var Gun = require('../gun'),
 	file = {};
 
 function isUsingFileJS (context) {
-	var gun = context.gun;
-	var opt = context.opt || gun.Back('opt') || {};
 
-	return opt.file !== false;
+	// Options passed via .get or .put.
+	var methodOptions = context.opt || {};
+
+	// Options set on the gun chain.
+	var chainOptions = context.gun.Back('opt') || {};
+
+	// Favor method options over chain options.
+	var file = methodOptions.hasOwnProperty('file')
+		? methodOptions.file
+		: chainOptions.file;
+
+	// Return whether the module is disabled.
+	return file !== false;
 }
 
 // queue writes, adapted from https://github.com/toolness/jsondown/blob/master/jsondown.js

--- a/lib/file.js
+++ b/lib/file.js
@@ -12,12 +12,12 @@ function isUsingFileJS (context) {
 	var methodOptions = context.opt || {};
 
 	// Options set on the gun chain.
-	var chainOptions = context.gun.Back('opt') || {};
+	var chainOption = context.gun.Back('opt.file');
 
 	// Favor method options over chain options.
 	var file = methodOptions.hasOwnProperty('file')
 		? methodOptions.file
-		: chainOptions.file;
+		: chainOption;
 
 	// Return whether the module is disabled.
 	return file !== false;


### PR DESCRIPTION
The FileJS module can be passed options in two ways, and this commit
ensures they're treated in the right way.
Previously, options passed as .put or .get parameters would be favored
over those used on the chain, even if `file` wasn't specified. Now, the
module will only use the method options if `file` is mentioned, falling
back to the chain options.
This was a mistake on my part with the first PR (#268), I failed to notice that edge case.