### PR TITLE
Optimistically open client sockets

### DIFF
--- a/gun.js
+++ b/gun.js
@@ -751,7 +751,7 @@
 				if(!f){
 					at.node = at.node || n || {};
 					if(obj_has(v, Node._)){
-						at.node._ = Gun.obj.copy(v._);
+						at.node._ = obj_copy(v._);
 					}
 					at.node = Node.soul.ify(at.node, Val.rel.is(at.rel));
 				}

--- a/lib/wsp/Peer.js
+++ b/lib/wsp/Peer.js
@@ -10,6 +10,7 @@ var util = require('util');
  * @param {Object} [options] - Override the default settings.
  * @param {Object} options.time=50 - Initial backoff time.
  * @param {Object} options.factor=2 - How much to multiply the time by.
+ * @param {Object} options.max=1min - Maximum backoff time.
  * @class
  */
 function Backoff (options) {
@@ -24,7 +25,14 @@ function Backoff (options) {
  * @return {Number} - The next backoff time.
  */
 Backoff.prototype.next = function () {
-	this.time *= this.factor;
+	var next = this.time * this.factor;
+
+	if (next > this.max) {
+		this.time = this.max;
+		return this.max;
+	}
+
+	this.time = next;
 
 	return this.time;
 };
@@ -38,6 +46,7 @@ Backoff.prototype.reset = function () {
 
 	this.time = options.time || 50;
 	this.factor = options.factor || 2;
+	this.max = options.max || 1 * 60 * 1000;
 
 	return this;
 };

--- a/lib/wsp/client.js
+++ b/lib/wsp/client.js
@@ -246,6 +246,11 @@ Gun.on('get', function (at) {
 	var gun = at.gun;
 	var opt = at.opt || {};
 	var peers = opt.peers || gun.Back('opt.peers');
+	var server = Tab.server || {};
+
+	var duplicated = server.msg || function () {
+		return false;
+	};
 
 	if (!peers || Gun.obj.empty(peers)) {
 		Gun.log.once('peers', 'Warning! You have no peers to connect to!');
@@ -264,20 +269,27 @@ Gun.on('get', function (at) {
 		'$': at.get,
 	};
 
+	if (duplicated(msg['#'])) {
+		return;
+	}
+
 	// Listen for a response.
 	// TODO: ONE? PERF! Clear out listeners, maybe with setTimeout?
 	Tab.on(msg['#'], function (err, data) {
+		var id = Gun.text.random();
+		var root = at.gun.Back(Infinity);
+
 		var obj = {
+			'#': id,
 			'@': at['#'],
 			err: err,
 			put: data,
+
+			// Flag, prevents rebroadcast.
+			nopush: true,
 		};
 
-		if (data) {
-			at.gun.Back(-1).on('out', obj);
-		} else {
-			at.gun.Back(-1).on('in', obj);
-		}
+		root.on(data ? 'out' : 'in', obj);
 	});
 
 	// Broadcast to all other peers.

--- a/lib/wsp/server-push.js
+++ b/lib/wsp/server-push.js
@@ -45,12 +45,19 @@ function ready (socket, cb) {
  * @return {undefined}
  */
 function request (context, clients, cb) {
+	var id = context['#'] || Gun.text.random(9);
+
+	Gun.on(id, function (err, data, event) {
+		cb(err, data);
+		event.off();
+	});
+
 	Gun.obj.map(clients, function (client) {
 		ready(client, function () {
 			var msg = {
 				headers: {},
 				body: {
-					'#': Gun.on.ask(cb),
+					'#': id,
 					'$': context.get,
 				},
 			};
@@ -69,12 +76,19 @@ function request (context, clients, cb) {
  * @return {undefined}
  */
 function update (context, clients, cb) {
+	var id = context['#'] || Gun.text.random(9);
+
+	Gun.on(id, function (err, data, event) {
+		cb(err, data);
+		event.off();
+	});
+
 	Gun.obj.map(clients, function (client) {
 		ready(client, function () {
 			var msg = {
 				headers: {},
 				body: {
-					'#': Gun.on.ask(cb),
+					'#': id,
 					'$': context.put,
 				},
 			};
@@ -125,6 +139,7 @@ function attach (gun, server) {
 		if (!isUsingServer(context.gun, server)) {
 			return;
 		}
+
 		request(context, pool, function (err, data) {
 			var response = {
 				'@': context['#'],
@@ -140,6 +155,10 @@ function attach (gun, server) {
 
 	Gun.on('put', function (context) {
 		if (!isUsingServer(context.gun, server)) {
+			return;
+		}
+
+		if (context.nopush) {
 			return;
 		}
 

--- a/lib/wsp/server.js
+++ b/lib/wsp/server.js
@@ -152,8 +152,24 @@ Gun.on('opt', function(at){
 			// TODO: BUG! server put should push.
 		}
 		tran.get = function(req, cb){
-			var body = req.body, lex = body['$'], reply = {headers: {'Content-Type': tran.json}}, opt;
-			gun.on('out', {gun: gun, get: lex, req: 1, '#': Gun.on.ask(function(at, ev){
+			var body = req.body, lex = body['$'], reply = {headers: {'Content-Type': tran.json}};
+
+			var graph = gun.Back(Infinity)._.graph;
+			var node = graph[lex['#']];
+			var result = Gun.graph.ify(node);
+
+			if (node) {
+				return cb({
+					headers: reply.headers,
+					body: {
+						'#': gun.wsp.msg(),
+						'@': body['#'],
+						'$': result,
+					},
+				});
+			}
+
+			gun.on('out', {gun: gun, get: lex, req: 1, '#': body['#'] || Gun.on.ask(function(at, ev){
 				ev.off();
 				var graph = at.put;
 				return cb({headers: reply.headers, body: {


### PR DESCRIPTION
Changes behavior from only opening sockets when absolutely necessary to
keeping them open for as long as possible. Key differences:

- Much higher success rate for messages sent from the connected server.
- Process no longer shuts down if nothing is done with gun, instead
  listens for incoming messages on client sockets.

Socket reconnect handle by Peer instances, meaning better handling for
deferred messages and predictable backoff.
The client.js logic has been significantly refactored. Among the
improvements, GET/PUT requests now respect the `peers` option for each
gun instance, only sending requests to the URLs listed.