### PR TITLE
Minify Gun at package publish-time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/*
 npm-debug.log
+gun.min.js
 yarn.lock
 *data.json
 *.db

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node examples/http.js 8080",
+    "prepublish": "uglifyjs2 gun.js -o gun.min.js -c -m",
     "test": "mocha",
     "unbuild": "node lib/unbuild.js"
   },
@@ -49,9 +50,10 @@
     "ws": "~>1.0.1"
   },
   "devDependencies": {
-    "mocha": "~>1.9.0",
     "express": "~>4.13.4",
+    "mocha": "~>1.9.0",
     "panic-server": "~>0.3.0",
-    "selenium-webdriver": "~>2.53.2"
+    "selenium-webdriver": "~>2.53.2",
+    "uglify-js2": "^2.1.11"
   }
 }


### PR DESCRIPTION
Inclusion of this 'prepublish' npm lifecycle script causes a minified gun.min.js to be generated at package publish-time, as well as part of the standard build workflow, so users can reference it from the Gun example servers. This mechanism utilizes https://www.npmjs.com/package/uglify-js2 to perform the minification, as a development dependency. It may be worthwhile to generate a source-map to enhance debugging output of the test suite when re-introduced.