### PR TITLE
Shallow copy constructor options

### DIFF
--- a/gun.js
+++ b/gun.js
@@ -905,22 +905,28 @@
 
 			Gun.chain.opt = function(opt){
 				opt = opt || {};
-				var gun = this, at = gun._, tmp, u;
+				var peers = obj_is(opt) ? opt.peers : opt;
+				if (text_is(peers)) {
+					peers = [peers];
+				}
+				if (list_is(peers)) {
+					peers = obj_map(peers, function (url, field, m) {
+						m(url, {});
+					});
+				}
+				if (!obj_is(opt)) {
+					opt = {};
+				}
+				opt.peers = peers;
+				var gun = this, at = gun._;
 				at.root = at.root || gun;
 				at.graph = at.graph || {};
 				at.dedup = new Dedup();
 				at.opt = at.opt || {};
-				if(text_is(opt)){ opt = {peers: opt} }
-				else if(list_is(opt)){ opt = {peers: opt} }
-				if(text_is(opt.peers)){ opt.peers = [opt.peers] }
-				if(list_is(opt.peers)){ opt.peers = obj_map(opt.peers, function(n,f,m){m(n,{})}) }
-				obj_map(opt, function map(v,f){
-					if(obj_is(v)){
-						obj_map(v, map, this[f] || (this[f] = {})); // TODO: Bug? Be careful of falsey values getting overwritten?
-						return;
-					}
-					this[f] = v;
-				}, at.opt);
+
+				at.opt.peers = Gun.obj.to(at.opt.peers || {}, peers);
+				Gun.obj.to(opt, at.opt);
+
 				Gun.on('opt', at);
 				if(!at.once){
 					gun.on('in', input, at);


### PR DESCRIPTION
Previously constructor options were deeply copied, which caused
issues with 3rd party plugins when they pass "class" instances as
options (since instances were copied into POJOs, breaking the prototype
chain). Now it's shallow copied. Special treatment is still given for
the `options.peers` property.

@amark, would you review?