### PR TITLE
pass gun's options to websocket

### DIFF
--- a/gun.js
+++ b/gun.js
@@ -2198,9 +2198,9 @@
 			);
 		}
 
-		function Client (url, options) {
+		function Client (url, options, wscOptions ) {
 			if (!(this instanceof Client)) {
-				return new Client(url, options);
+				return new Client(url, options, wscOptions);
 			}
 
 			this.url = Client.formatURL(url);
@@ -2211,6 +2211,7 @@
 			this.on = Gun.on;
 
 			this.options = options || {};
+			this.options.wsc = wscOptions;
 			this.resetBackoff();
 		}
 
@@ -2234,7 +2235,7 @@
 
 			connect: function () {
 				var client = this;
-				var socket = new Client.WebSocket(this.url);
+				var socket = new Client.WebSocket(this.url, this.options.wsc.protocols, this.options.wsc );
 				this.socket = socket;
 
 				// Forward messages into the emitter.
@@ -2416,7 +2417,7 @@
 					return;
 				}
 
-				var client = new Client(url, options.backoff);
+				var client = new Client(url, options.backoff, gun.Back('opt.wsc') || {protocols:null});
 
 				// Add it to the pool.
 				Client.pool[url] = client;

--- a/lib/wsp/Peer.js
+++ b/lib/wsp/Peer.js
@@ -83,6 +83,7 @@ function Peer (url, options) {
 	this.setMaxListeners(Infinity);
 
 	this.options = options || {};
+        this.options.wsc = options.wsc || { protocols: null };
 
 	// Messages sent before the socket is ready.
 	this.deferredMsgs = [];
@@ -134,7 +135,7 @@ API.connect = function () {
 	var url = this.url;
 
 	// Open a new websocket.
-	var socket = new WebSocket(url, this.options.wsc);
+	var socket = new WebSocket(url, this.options.wsc.protocols, this.options.wsc);
 
 	// Re-use the previous listeners.
 	socket._events = this._events;

--- a/lib/wsp/Peer.js
+++ b/lib/wsp/Peer.js
@@ -134,7 +134,7 @@ API.connect = function () {
 	var url = this.url;
 
 	// Open a new websocket.
-	var socket = new WebSocket(url);
+	var socket = new WebSocket(url, this.options);
 
 	// Re-use the previous listeners.
 	socket._events = this._events;

--- a/lib/wsp/Peer.js
+++ b/lib/wsp/Peer.js
@@ -134,7 +134,7 @@ API.connect = function () {
 	var url = this.url;
 
 	// Open a new websocket.
-	var socket = new WebSocket(url, this.options);
+	var socket = new WebSocket(url, this.options.wsc);
 
 	// Re-use the previous listeners.
 	socket._events = this._events;

--- a/lib/wsp/Peer.js
+++ b/lib/wsp/Peer.js
@@ -83,7 +83,7 @@ function Peer (url, options) {
 	this.setMaxListeners(Infinity);
 
 	this.options = options || {};
-	if( !('wsc' in this.options ) ) this.options.wsc = options.wsc || { protocols: null };
+	if( !('wsc' in this.options ) ) this.options.wsc = { protocols: null };
 	else if( !('protocols' in this.options.wsc) ) this.options.wsc.protocols = null;   
 
 	// Messages sent before the socket is ready.

--- a/lib/wsp/Peer.js
+++ b/lib/wsp/Peer.js
@@ -83,7 +83,8 @@ function Peer (url, options) {
 	this.setMaxListeners(Infinity);
 
 	this.options = options || {};
-        this.options.wsc = options.wsc || { protocols: null };
+        if( !('wsc" in this.options ) ) this.options.wsc = options.wsc || { protocols: null };
+	else if( !("protocols" in this.options.wsc) ) this.options.wsc.protocols = null;   
 
 	// Messages sent before the socket is ready.
 	this.deferredMsgs = [];

--- a/lib/wsp/Peer.js
+++ b/lib/wsp/Peer.js
@@ -83,7 +83,7 @@ function Peer (url, options) {
 	this.setMaxListeners(Infinity);
 
 	this.options = options || {};
-        if( !('wsc' in this.options ) ) this.options.wsc = options.wsc || { protocols: null };
+	if( !('wsc' in this.options ) ) this.options.wsc = options.wsc || { protocols: null };
 	else if( !('protocols' in this.options.wsc) ) this.options.wsc.protocols = null;   
 
 	// Messages sent before the socket is ready.

--- a/lib/wsp/Peer.js
+++ b/lib/wsp/Peer.js
@@ -83,8 +83,8 @@ function Peer (url, options) {
 	this.setMaxListeners(Infinity);
 
 	this.options = options || {};
-        if( !('wsc" in this.options ) ) this.options.wsc = options.wsc || { protocols: null };
-	else if( !("protocols" in this.options.wsc) ) this.options.wsc.protocols = null;   
+        if( !('wsc' in this.options ) ) this.options.wsc = options.wsc || { protocols: null };
+	else if( !('protocols' in this.options.wsc) ) this.options.wsc.protocols = null;   
 
 	// Messages sent before the socket is ready.
 	this.deferredMsgs = [];


### PR DESCRIPTION
I recently had to set options given to the websocket client especially 

rejectUnauthorized {Boolean} Verify or not the server certificate.

for connecting to wss which are using self signed certs...
could also pass things like 'protocol' to differentiate a Gun websocket connection from some other websocket connection....

I don't know if maybe websock options should be a object in options instead ?  To avoid namespace collision?