### PR TITLE
0.4 websocket migration

### DIFF
--- a/gun.js
+++ b/gun.js
@@ -2417,7 +2417,7 @@
 					return;
 				}
 
-				var client = new Client(url, options.backoff, gun.Back('opt.wsc') || {protocols:null});
+				var client = new Client(url, options.backoff, gun.Back('opt.wsc') || {protocols:['gun']});
 
 				// Add it to the pool.
 				Client.pool[url] = client;

--- a/gun.js
+++ b/gun.js
@@ -2198,9 +2198,9 @@
 			);
 		}
 
-		function Client (url, options) {
+		function Client (url, options, wscOptions ) {
 			if (!(this instanceof Client)) {
-				return new Client(url, options);
+				return new Client(url, options, wscOptions);
 			}
 
 			this.url = Client.formatURL(url);
@@ -2211,6 +2211,7 @@
 			this.on = Gun.on;
 
 			this.options = options || {};
+			this.options.wsc = wscOptions;
 			this.resetBackoff();
 		}
 
@@ -2234,7 +2235,7 @@
 
 			connect: function () {
 				var client = this;
-				var socket = new Client.WebSocket(this.url);
+				var socket = new Client.WebSocket(this.url, this.options.wsc.protocols, this.options.wsc );
 				this.socket = socket;
 
 				// Forward messages into the emitter.
@@ -2416,7 +2417,7 @@
 					return;
 				}
 
-				var client = new Client(url, options.backoff);
+				var client = new Client(url, options.backoff, gun.Back('opt.wsc') || {protocols:null});
 
 				// Add it to the pool.
 				Client.pool[url] = client;

--- a/lib/wsp/Peer.js
+++ b/lib/wsp/Peer.js
@@ -83,7 +83,7 @@ function Peer (url, options) {
 	this.setMaxListeners(Infinity);
 
 	this.options = options || {};
-	if( !('wsc' in this.options ) ) this.options.wsc = options.wsc || { protocols: null };
+	if( !('wsc' in this.options ) ) this.options.wsc = { protocols: null };
 	else if( !('protocols' in this.options.wsc) ) this.options.wsc.protocols = null;   
 
 	// Messages sent before the socket is ready.

--- a/lib/wsp/Peer.js
+++ b/lib/wsp/Peer.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 'use strict';
 
-var WebSocket = require('ws');
+var WebSocket = require('websocket');
 var Emitter = require('events');
 var util = require('util');
 

--- a/lib/wsp/Peer.js
+++ b/lib/wsp/Peer.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-underscore-dangle */
 'use strict';
 
-var WebSocket = require('websocket').Client;
+var WebSocket = require('websocket').w3cwebsocket;
 var Emitter = require('events');
 var util = require('util');
 

--- a/lib/wsp/client.js
+++ b/lib/wsp/client.js
@@ -76,7 +76,7 @@ Gun.on('opt', function (context) {
 		if (sockets[url]) {
 			return;
 		}
-		if (!options.wsc) options.wsc = gun.Back('opt.wsc') || { protocols:null };
+		if (!options.wsc) options.wsc = gun.Back('opt.wsc') || { protocols:["gun"] };
 
 		var socket = Socket(url, options);
 		sockets.add(url, socket);

--- a/lib/wsp/client.js
+++ b/lib/wsp/client.js
@@ -82,7 +82,7 @@ Gun.on('opt', function (context) {
 			var request;
 
 			try {
-				request = JSON.parse(msg);
+				request = JSON.parse(msg.utf8Data);
 			} catch (error) {
 				return;
 			}

--- a/lib/wsp/server-push.js
+++ b/lib/wsp/server-push.js
@@ -63,7 +63,9 @@ function attach (gun, server) {
 	root._.servers.push(server);
 	var pool = {};
 	var sid = Gun.text.random();
-	server.on('connect', function (socket) {
+	server.on('request', function (socket) {
+                var socket = socket.accept( null, null );
+	//server.on('connection', function (socket) {
 	//server.on('connection', function (socket) {
 		socket.id = socket.id || Gun.text.random(10);
 		pool[socket.id] = socket;

--- a/lib/wsp/server-push.js
+++ b/lib/wsp/server-push.js
@@ -64,8 +64,6 @@ function attach (gun, server) {
 	var pool = {};
 	var sid = Gun.text.random();
 	server.on('request', function (socket) {
-                var socket = socket.accept( null, null );
-	//server.on('connection', function (socket) {
 	//server.on('connection', function (socket) {
 		socket.id = socket.id || Gun.text.random(10);
 		pool[socket.id] = socket;

--- a/lib/wsp/server-push.js
+++ b/lib/wsp/server-push.js
@@ -63,7 +63,7 @@ function attach (gun, server) {
 	root._.servers.push(server);
 	var pool = {};
 	var sid = Gun.text.random();
-	server.on('request', function (socket) {
+	server.on('connect', function (socket) {
 	//server.on('connection', function (socket) {
 		socket.id = socket.id || Gun.text.random(10);
 		pool[socket.id] = socket;

--- a/lib/wsp/server-push.js
+++ b/lib/wsp/server-push.js
@@ -63,12 +63,13 @@ function attach (gun, server) {
 	root._.servers.push(server);
 	var pool = {};
 	var sid = Gun.text.random();
-	server.on('connection', function (socket) {
+	server.on('connect', function (socket) {
+	//server.on('connection', function (socket) {
 		socket.id = socket.id || Gun.text.random(10);
 		pool[socket.id] = socket;
 		/*
 		socket.on('message', function (message) {
-			var data = Gun.obj.ify(message);
+			var data = Gun.obj.ify(message.utf8Data);
 
 			if (!data || !data.body) {
 				return;

--- a/lib/wsp/server.js
+++ b/lib/wsp/server.js
@@ -30,7 +30,7 @@ Gun.on('opt', function (at) {
 					req.accept(r, null);
 				else {
 					//gun.wsp.ws.emit( 'request', req );
-					console.log( "no accept... no reject.. return...(callback to foward request?)" );
+					console.log( "no accept... no reject.. return...(callback to foward request?)", gun.__.opt.ws.protocol, "protocolmap:", req.protocolFullCaseMap );
 				}
 			});
 			attach(gun, gun.wsp.ws);

--- a/lib/wsp/server.js
+++ b/lib/wsp/server.js
@@ -3,8 +3,8 @@
 var Gun = require('../../gun');
 var http = require('../http');
 var url = require('url');
-var WS = require('ws');
-var WSS = WS.Server;
+var WS = require('websocket');
+var WSS = WS.server;
 var attach = require('./server-push');
 
 // Handles server to server sync.
@@ -13,16 +13,26 @@ require('./client.js');
 Gun.on('opt', function (at) {
 	var gun = at.gun, opt = at.opt;
 	gun.__ = at.root._;
-	gun.__.opt.ws = opt.ws = gun.__.opt.ws || opt.ws || {};
-
+	gun.__.opt.ws = opt.ws = gun.__.opt.ws || opt.ws || { protocol:'gun' };
+	if( !("protocol" in opt.ws ) ) opt.ws.protocol = "gun";
 	function start (server, port, app) {
 		if (app && app.use) {
 			app.use(gun.wsp.server);
 		}
-		server = gun.__.opt.ws.server = gun.__.opt.ws.server || opt.ws.server || server;
+		server = gun.__.opt.ws.httpServer = gun.__.opt.ws.server || opt.ws.server || server;
 
 		if (!gun.wsp.ws) {
 			gun.wsp.ws = new WSS(gun.__.opt.ws);
+			gun.wsp.ws.on('request', function (req) {
+				//console.log( "(2)accept request: ", req.protocolFullCaseMap, req.requestedProtocols, gun.__.opt.ws.protocol );
+                                var r;
+				if( r = req.requestedProtocols.find( function(p){ return req.protocolFullCaseMap[p]===gun.__.opt.ws.protocol } ) )
+					req.accept(r, null);
+				else {
+					//gun.wsp.ws.emit( 'request', req );
+					console.log( "no accept... no reject.. return...(callback to foward request?)" );
+				}
+			});
 			attach(gun, gun.wsp.ws);
 		}
 

--- a/lib/wsp/ws.js
+++ b/lib/wsp/ws.js
@@ -1,7 +1,8 @@
 var Gun = require('../../gun')
 ,	url = require('url');
 module.exports = function(wss, server, opt){
-	wss.on('connection', function(ws){
+	wss.on('connect', function(ws){
+        //wss.on('connection', function(ws){
 		var req = {};
 		ws.upgradeReq = ws.upgradeReq || {};
 		req.url = url.parse(ws.upgradeReq.url||'');
@@ -9,7 +10,7 @@ module.exports = function(wss, server, opt){
 		req.headers = ws.upgradeReq.headers || {};
 		//Gun.log("wsReq", req);
 		ws.on('message', function(msg){
-			msg = Gun.obj.ify(msg);
+			msg = Gun.obj.ify(msg.utf8Data);
 			msg.url = msg.url || {};
 			msg.url.pathname = (req.url.pathname||'') + (msg.url.pathname||'');
 			Gun.obj.map(req.url, function(val, i){

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "aws-sdk": "~>2.0.0",
     "formidable": "~>1.0.15",
-    "ws": "~>1.0.1"
+    "websocket": "~>1.0.23"
   },
   "devDependencies": {
     "express": "~>4.13.4",


### PR DESCRIPTION
This version uses 'websocket' which allows connecting with 'wss:' instead of just 'ws:'

Adds some protocol options?

Does update to use protocol 'gun' by default.
This will cause issues if server and client mismatch.

I ran into a issue connecting server-server using Peer.js; should be fixed ( will test tomorrow )