### PR TITLE
Quick fix to let browserified packages require gun.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.5.8",
   "description": "Graph engine",
   "main": "index.js",
+  "browser": "gun.min.js",
   "scripts": {
     "start": "node examples/http.js 8080",
     "prepublish": "npm run unbuild",


### PR DESCRIPTION
Without this browserify will complain that it can't find all pieces of
gun.js, because it parses the AST for instances of 'require' and doesn't
realize that require has been redefined and they are already present.

(also it'll pull in all the bits of lib/server.js, which doesn't make sense)