### PR TITLE
ensure replaced http is at beginning of url

### DIFF
--- a/gun.js
+++ b/gun.js
@@ -2237,7 +2237,7 @@
 
 		// Ensure the protocol is correct.
 		Client.formatURL = function (url) {
-			return url.replace('http', 'ws');
+			return url.replace(/^http/, 'ws');
 		};
 
 		// Send a message to a group of peers.

--- a/lib/wsp/Peer.js
+++ b/lib/wsp/Peer.js
@@ -120,7 +120,7 @@ function Peer (url, options) {
 Peer.formatURL = function (url) {
 
 	// Works for `https` and `wss` URLs, too.
-	return url.replace('http', 'ws');
+	return url.replace(/^http/, 'ws');
 };
 
 util.inherits(Peer, Emitter);


### PR DESCRIPTION
fixes a potential bug where part of the `ws` url contains `'http'`