### PR TITLE
Add get options cat.wsp

### DIFF
--- a/examples/http-external-ws.js
+++ b/examples/http-external-ws.js
@@ -36,7 +36,7 @@ wss.on('connection',acceptConnection )
 var gunPeers = [];  // used as a list of connected clients.
 
 Gun.on('out', function(msg){
-	msg = JSON.stringify({headers:{},body:msg});
+	msg = JSON.stringify(msg);
 	gunPeers.forEach( function(peer){ peer.send( msg ) })
 })
 function acceptConnection( connection ) {
@@ -46,7 +46,7 @@ function acceptConnection( connection ) {
     gunPeers.push( connection );
     connection.on( 'error',function(error){console.log( "WebSocket Error:", error) } );
     
-    connection.on( 'message',function(msg){gun.on('in',JSON.parse( msg).body)})
+    connection.on( 'message',function(msg){gun.on('in',JSON.parse( msg))})
     connection.on( 'close', function(reason,desc){
         // gunpeers gone.
         var i = gunPeers.findIndex( function(p){return p===connection} );

--- a/gun.js
+++ b/gun.js
@@ -2375,7 +2375,7 @@
 		function open(peer, as){
 			if(!peer || !peer.url){ return }
 			var url = peer.url.replace('http', 'ws');
-			var wire = peer.wire = new WebSocket(url, peer.wsc.protocols, peer.wsc );
+			var wire = peer.wire = new WebSocket(url, this.wsc.protocols, this.wsc );
 			wire.onclose = function(){
 				reconnect(peer, as);
 			};

--- a/gun.js
+++ b/gun.js
@@ -2375,7 +2375,7 @@
 		function open(peer, as){
 			if(!peer || !peer.url){ return }
 			var url = peer.url.replace('http', 'ws');
-			var wire = peer.wire = new WebSocket(url, as.wsc.protocols, as.wsc );
+			var wire = peer.wire = new WebSocket(url, as.wsp.wsc.protocols, as.wsp.wsc );
 			wire.onclose = function(){
 				reconnect(peer, as);
 			};

--- a/gun.js
+++ b/gun.js
@@ -2375,7 +2375,7 @@
 		function open(peer, as){
 			if(!peer || !peer.url){ return }
 			var url = peer.url.replace('http', 'ws');
-			var wire = peer.wire = new WebSocket(url, this.wsc.protocols, this.wsc );
+			var wire = peer.wire = new WebSocket(url, as.wsc.protocols, as.wsc );
 			wire.onclose = function(){
 				reconnect(peer, as);
 			};

--- a/gun.js
+++ b/gun.js
@@ -2323,7 +2323,7 @@
 
 		Gun.on('out', function(at){
 			this.to.next(at);
-			var cat = at.gun._.root._, wsp = cat.wsp || (cat.wsp = {});
+			var cat = at.gun._.root._, wsp = cat.wsp || (cat.wsp = {wsc: at.gun.back('opt.wsc') || {protocols:null} });
 			if(at.wsp && 1 === wsp.count){ return } // if the message came FROM the only peer we are connected to, don't echo it back.
 			message = JSON.stringify(at);
 			//if(++count){ console.log("msg OUT:", count, Gun.obj.ify(message)) }
@@ -2375,7 +2375,7 @@
 		function open(peer, as){
 			if(!peer || !peer.url){ return }
 			var url = peer.url.replace('http', 'ws');
-			var wire = peer.wire = new WebSocket(url);
+			var wire = peer.wire = new WebSocket(url, peer.wsc.protocols, peer.wsc );
 			wire.onclose = function(){
 				reconnect(peer, as);
 			};

--- a/gun.js
+++ b/gun.js
@@ -2376,7 +2376,7 @@
 		function open(peer, as){
 			if(!peer || !peer.url){ return }
 			var url = peer.url.replace('http', 'ws');
-			var wire = peer.wire = new WebSocket(url, as.wsp.wsc.protocols, as.wsp.wsc );
+			var wire = peer.wire = new WebSocket(url, as.opt.wsc.protocols, as.opt.wsc );
 			wire.onclose = function(){
 				reconnect(peer, as);
 			};

--- a/gun.js
+++ b/gun.js
@@ -2338,8 +2338,10 @@
 				if(!cat.udrain){ return }
 				var tmp = cat.udrain;
 				cat.udrain = null;
-				message = JSON.stringify(tmp);
-				Gun.obj.map(cat.opt.peers, send, cat);
+				if( tmp.length ) {
+					message = JSON.stringify(tmp);
+					Gun.obj.map(cat.opt.peers, send, cat);
+				}
 			},1);
 			wsp.count = 0;
 			Gun.obj.map(cat.opt.peers, send, cat);

--- a/gun.js
+++ b/gun.js
@@ -929,6 +929,7 @@
 					if(!obj_is(at.opt.peers)){ at.opt.peers = {}}
 					at.opt.peers = obj_to(tmp, at.opt.peers);
 				}
+				at.opt.wsc = at.opt.wsc || {protocols:null} 
 				at.opt.peers = at.opt.peers || {};
 				obj_to(opt, at.opt); // copies options on to `at.opt` only if not already taken.
 				Gun.on('opt', at);
@@ -2323,7 +2324,7 @@
 
 		Gun.on('out', function(at){
 			this.to.next(at);
-			var cat = at.gun._.root._, wsp = cat.wsp || (cat.wsp = {wsc: at.gun.back('opt.wsc') || {protocols:null} });
+			var cat = at.gun._.root._, wsp = cat.wsp || (cat.wsp = {});
 			if(at.wsp && 1 === wsp.count){ return } // if the message came FROM the only peer we are connected to, don't echo it back.
 			message = JSON.stringify(at);
 			//if(++count){ console.log("msg OUT:", count, Gun.obj.ify(message)) }


### PR DESCRIPTION
gets options passed to Gun( { wsc: { ...} } ) and puts wsc options in wsp which is used to contain a working state 'count' right now.  In addition to 'count' it will now contain 'wsc' which are the options passed to the gun instance.  This is cached on the 'cat' so the lookup should only be one time.
Since 'cat' becomes 'peer' later, peer.wsp.wsc are the new options.  These will always exist for the WebSocket call.  They default to 'null' and or Empty so no change will be expected without additional options.