### PR TITLE
Update wsc.protocols default

### DIFF
--- a/gun.js
+++ b/gun.js
@@ -1003,7 +1003,7 @@
 					if(!obj_is(at.opt.peers)){ at.opt.peers = {}}
 					at.opt.peers = obj_to(tmp, at.opt.peers);
 				}
-				at.opt.wsc = at.opt.wsc || {protocols:null} 
+				at.opt.wsc = at.opt.wsc || {protocols:''} 
 				at.opt.peers = at.opt.peers || {};
 				obj_to(opt, at.opt); // copies options on to `at.opt` only if not already taken.
 				Gun.on('opt', at);


### PR DESCRIPTION
.... to be '' instead of null.
https://developer.mozilla.org/en-US/docs/Web/API/WebSocket
If you don't specify a protocol string, an empty string is assumed.