### PR TITLE
Make the `file: false` option work again

### DIFF
--- a/lib/file.js
+++ b/lib/file.js
@@ -9,10 +9,10 @@ fs = require('fs');
 Gun.on('opt', function(ctx){
 	this.to.next(ctx);
 	var opt = ctx.opt;
-	if(ctx.once){ return }
+	if(ctx.once || (opt && opt.file === false)){ return }
 	opt.file = String(opt.file || 'data.json');
 	var graph = ctx.graph, acks = {}, count = 0, to;
-	var disk = Gun.obj.ify((fs.existsSync || require('path').existsSync)(opt.file)? 
+	var disk = Gun.obj.ify((fs.existsSync || require('path').existsSync)(opt.file)?
 		fs.readFileSync(opt.file).toString()
 	: null) || {};
 
@@ -21,7 +21,7 @@ Gun.on('opt', function(ctx){
 		'WARNING! This `file.js` module for gun is ' +
 		'intended for local development testing only!'
 	);
-	
+
 	ctx.on('put', function(at){
 		this.to.next(at);
 		Gun.graph.is(at.put, null, map);


### PR DESCRIPTION
Adds in the option to disable the file plugin again. Looks like [a recent refactor](https://github.com/amark/gun/commit/4db1ae9872b4ff38444bf92941acad488281f453#diff-2) removed that option. I'm guessing it was inadvertent.

In code stuff:

```js
// Gun will currently use the file plugin anyway.
var gun = require('gun')({ file: false })
```