### PR TITLE
enable ack delay

### DIFF
--- a/gun.js
+++ b/gun.js
@@ -765,11 +765,11 @@
 				if(!this.on){ return }
 				var id = text_rand(9);
 				if(cb){ 
-					var to = this.on(id, cb, as);
+					var to = this.on(id, cb, as), delay = (this.gun._.opt.ackDelay || 9);
 					to.err = setTimeout(function(){
 						to.next({err: "Error: No ACK received yet."});
 						to.off();
-					}, 1000 * 9); // TODO: Make configurable!!!
+					}, 1000 * (delay < 1 ? 1 : delay));
 				}
 				return id;
 			}

--- a/gun.js
+++ b/gun.js
@@ -765,7 +765,7 @@
 				if(!this.on){ return }
 				var id = text_rand(9);
 				if(cb){ 
-					var to = this.on(id, cb, as), delay = (this.gun._.opt.lack || 9000);
+					var to = this.on(id, cb, as), lack = (this.gun._.opt.lack || 9000);
 					to.err = setTimeout(function(){
 						to.next({err: "Error: No ACK received yet."});
 						to.off();

--- a/gun.js
+++ b/gun.js
@@ -765,11 +765,11 @@
 				if(!this.on){ return }
 				var id = text_rand(9);
 				if(cb){ 
-					var to = this.on(id, cb, as), delay = (this.gun._.opt.ackDelay || 9);
+					var to = this.on(id, cb, as), delay = (this.gun._.opt.lack || 9000);
 					to.err = setTimeout(function(){
 						to.next({err: "Error: No ACK received yet."});
 						to.off();
-					}, 1000 * (delay < 1 ? 1 : delay));
+					}, lack < 1000 ? 1000 : lack);
 				}
 				return id;
 			}


### PR DESCRIPTION
Addressing the TODO comment here. Although I had wired up my test in a naive way, making this configurable was part of the solution for em.

What do you think of `ackDelay` as the option name? Open to something else too.

Also, seemed prudent to make sure that the `ackDelay` couldn't be less than 1 but that could be debated as well.