### PR TITLE
Prevent default on checkbox

### DIFF
--- a/examples/vue/todo.html
+++ b/examples/vue/todo.html
@@ -68,7 +68,7 @@
         <h3>Active</h3>
 
         <div v-for="active in activeTodos">
-            <label><input type="checkbox" @click="completeTodo(active.key)"> {{ active.todo.description }}</label>
+            <label><input type="checkbox" @click.prevent="completeTodo(active.key)"> {{ active.todo.description }}</label>
         </div>
 
         <h5 v-show="completedTodos.length > 0" class="completed-header">Completed</h5>


### PR DESCRIPTION
Added prevent default so that a checkbox won't remain wrongfully checked after marking a todo complete