### PR TITLE
Support `load` plugin in node

### DIFF
--- a/lib/load.js
+++ b/lib/load.js
@@ -1,4 +1,8 @@
-var Gun = Gun || require('../gun');
+if(typeof window !== "undefined"){
+  var Gun = window.Gun;
+} else {
+  var Gun = require('gun/gun');
+}
 Gun.chain.open || require('gun/lib/open');
 
 Gun.chain.load = function(cb, opt, at){


### PR DESCRIPTION
Relying on `Gun` being globally available is not valid in most cases
where a module loader is being used to import the `load` plugin.
Instead, pull `Gun` from window if window is defined, otherwise require
it using the module loader.

Resolves https://github.com/amark/gun/issues/504