### PR TITLE
Fix SEA sha1hash for ossl and keyid

### DIFF
--- a/sea.js
+++ b/sea.js
@@ -272,7 +272,7 @@
     // This internal func returns SHA-1 hashed data for KeyID generation
     const __shim = USE('./shim')
     const subtle = __shim.subtle
-    const ossl = __shim.ossl ? __shim.__ossl : subtle
+    const ossl = __shim.ossl ? __shim.ossl : subtle
     const sha1hash = (b) => ossl.digest({name: 'SHA-1'}, new ArrayBuffer(b))
     module.exports = sha1hash
   })(USE, './sha1');
@@ -629,7 +629,7 @@
       try {
         // base64('base64(x):base64(y)') => Buffer(xy)
         const pb = Buffer.concat(
-          Buffer.from(pub, 'base64').toString('utf8').split(':')
+          pub.replace(/-/g, '+').replace(/_/g, '/').split('.')
           .map((t) => Buffer.from(t, 'base64'))
         )
         // id is PGPv4 compliant raw key

--- a/sea/sea.js
+++ b/sea/sea.js
@@ -49,7 +49,7 @@
       try {
         // base64('base64(x):base64(y)') => Buffer(xy)
         const pb = Buffer.concat(
-          Buffer.from(pub, 'base64').toString('utf8').split(':')
+          pub.replace(/-/g, '+').replace(/_/g, '/').split('.')
           .map((t) => Buffer.from(t, 'base64'))
         )
         // id is PGPv4 compliant raw key

--- a/sea/sha1.js
+++ b/sea/sha1.js
@@ -2,7 +2,7 @@
     // This internal func returns SHA-1 hashed data for KeyID generation
     const __shim = require('./shim')
     const subtle = __shim.subtle
-    const ossl = __shim.ossl ? __shim.__ossl : subtle
+    const ossl = __shim.ossl ? __shim.ossl : subtle
     const sha1hash = (b) => ossl.digest({name: 'SHA-1'}, new ArrayBuffer(b))
     module.exports = sha1hash
   

--- a/test/sea/sea.html
+++ b/test/sea/sea.html
@@ -1,6 +1,6 @@
-<script src="../gun.js"></script>
-<script src="../lib/cryptomodules.js"></script>
-<script src="../sea.js"></script>
+<script src="../../gun.js"></script>
+<script src="../../lib/cryptomodules.js"></script>
+<script src="../../sea.js"></script>
 <script>
 ;(function(){
 	localStorage.clear();
@@ -12,7 +12,17 @@
 
 	function login(ack){
 		console.log("login...");
-		user.auth('alice', 'unsafepassword', write);
+		user.auth('alice', 'unsafepassword', keys);
+	}
+
+	function keys(data){
+		console.log("keys...");
+		const keys = user.pair();
+		console.log(keys);
+		Gun.SEA.keyid(keys.pub).then(function (keyid) {
+			console.log("Public key KeyID (PGPv4): " + keyid);
+			write(keys);
+		});
 	}
 
 	function write(data){


### PR DESCRIPTION
**Summary:**
SEA `keyid` and `sha1hash` functions are broken.

**Repro:**
```
;(async () => {
    var pair = await Gun.SEA.pair()
    console.log(pair.pub)
    try {
        var keyid = await Gun.SEA.keyid(pair.pub)
        console.log(keyid)
    } catch (e) { console.log(e) }
})();
```
**Details:**
Using the above reproducible code snippet we obtain the following:
 1. For node, a `TypeError: Cannot read property 'digest' of undefined` error is thrown.
 2. For the browser, a `DOMException: Failed to execute 'atob' on 'Window': The string to be decoded is not correctly encoded.` error is thrown. 

**Fix:**
For [1], the `sha1hash` function is updated so that the proper OSSL instance is used which resides in `__shim.ossl` instead of `__shim.__ossl`. For [2], as per [IETF-JWT](https://tools.ietf.org/html/draft-ietf-jose-json-web-key-41), the public key is exported to JWT which is base64url encoded and is converted to proper base64 encoding before splitting the x and y coordinates which uses a `.` as a separator (see `pair` function to confirm symmetry).