### PR TITLE
Short circuit in ask if no as is provided

### DIFF
--- a/src/ask.js
+++ b/src/ask.js
@@ -2,7 +2,7 @@
 // request / response module, for asking and acking messages.
 require('./onto'); // depends upon onto!
 module.exports = function ask(cb, as){
-	if(!this.on){ return }
+	if(!this.on || !as){ return }
 	if(!(cb instanceof Function)){
 		if(!cb || !as){ return }
 		var id = cb['#'] || cb, tmp = (this.tag||empty)[id];


### PR DESCRIPTION
IDK if this has unintended consequences; but it stops a lot of apparently extraneous "No ACK received yet" errors for me; I've noticed that when I have these errors "as" is always undefined.

May well be something broken higher up that should be fixed instead.