### PR TITLE
Fix apparent copy/paste error in rindexed.js

### DIFF
--- a/lib/rindexed.js
+++ b/lib/rindexed.js
@@ -57,7 +57,7 @@
         };
       }
       if(!db){
-        waitDbReady(doGet, 100, function(){
+        waitDbReady(doPut, 100, function(){
           var es = 'ERROR: Timeout: RAD IndexedDB not ready.';
           console.log(es);
           cb(es, undefined);


### PR DESCRIPTION
Looks like this should be doPut instead of doGet since doGet is not defined in this scope.