### PR TITLE
Make node-webcrypto-ossl an optional dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,8 +49,10 @@
   },
   "dependencies": {
     "text-encoding": "^0.7.0",
-    "node-webcrypto-ossl": "^1.0.39",
     "ws": "~>5.2.0"
+  },
+  "optionalDependencies": {
+    "node-webcrypto-ossl": "^1.0.39"
   },
   "devDependencies": {
     "aws-sdk": ">=2.153.0",


### PR DESCRIPTION
`node-webcrypto-ossl` is a native Node package, and will only be used in a very specific instance (using SEA from Node).

In my case, and I suppose in many others', SEA in Node will never be used.

I'd like to have that dependency made optional, since a failure to require it [is already handled](https://github.com/amark/gun/blob/535d6569fcff380faefe8ffafbeb658a1635b74f/sea.js#L183). Furthermore on Windows it requires the entire native build toolchain to be installed, which is not ideal for such a small feature.