### PR TITLE
bye.js fix (support new mesh)

### DIFF
--- a/lib/bye.js
+++ b/lib/bye.js
@@ -5,8 +5,8 @@ Gun.on('opt', function(root){
 	if(root.once){ return }
 	root.on('in', function(msg){
 		//Msg did not have a peer property saved before, so nothing ever went further
-		if(!msg.mesh || !msg.BYE){ return this.to.next(msg) }
-		var peer = msg.mesh.via;
+		if(!msg._ || !msg.BYE){ return this.to.next(msg) }
+		var peer = msg._.via;
 		(peer.bye = peer.bye || []).push(msg.BYE);
 	})
 	root.on('bye', function(peer){


### PR DESCRIPTION
I am using gundb 0.8.1 0.2019.331 and noticed not working bye method when programming web application on this version.
Maybe this is happened because bye() access to outdated mesh structure.
seems to work just fine.
:-)