### PR TITLE
fix: settings can be from opts or from process.env

### DIFF
--- a/lib/rs3.js
+++ b/lib/rs3.js
@@ -7,7 +7,7 @@ var u, AWS;
 Gun.on('create', function(root){
 	this.to.next(root);
 	var opt = root.opt;
-	if(!process.env.AWS_S3_BUCKET){ return }
+	if(!opt.s3 && !process.env.AWS_S3_BUCKET){ return }
 	opt.batch = opt.batch || (1000 * 10);
 	opt.until = opt.until || (1000 * 3);
 	opt.chunk = opt.chunk || (1024 * 1024 * 10); // 10MB


### PR DESCRIPTION
if you provide s3 in Gun({opts}) it wont work since it checks for process.env.AWS_S3_BUCKET
fixed so it checks if either exists