### PR TITLE
[SEA] Migrate from `node-webcrypto-ossl` to `@peculiar/webcrypto`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,59 @@
 {
   "name": "gun",
-  "version": "0.2019.711",
+  "version": "0.2019.910",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@peculiar/asn1-schema": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-1.0.3.tgz",
+      "integrity": "sha512-Tfgj9eNJ6cTKEtEuidKenLHMx/Q5M8KEE9hnohHqvdpqHJXWYr5RlT3GjAHPjGXy5+mr7sSfuXfzE6aAkEGN7A==",
+      "optional": true,
+      "requires": {
+        "asn1js": "^2.0.22",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@peculiar/json-schema": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@peculiar/json-schema/-/json-schema-1.1.5.tgz",
+      "integrity": "sha512-y5XYA3pf9+c+YKVpWnPtQbNmlNCs2ehNHyMLJvq4K5Fjwc1N64YGy7MNecKW3uYLga+sqbGTQSUdOdlnaRRbpA==",
+      "optional": true,
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
+    "@peculiar/webcrypto": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@peculiar/webcrypto/-/webcrypto-1.0.19.tgz",
+      "integrity": "sha512-+lF69A18LJBLp0/gJIQatCARLah6cTUmLwY0Cdab0zsk+Z53BcpjKQyyP4LIN8oW601ZXv28mWEQ4Cm7MllF6w==",
+      "optional": true,
+      "requires": {
+        "@peculiar/asn1-schema": "^1.0.3",
+        "@peculiar/json-schema": "^1.1.5",
+        "asn1js": "^2.0.26",
+        "pvtsutils": "^1.0.6",
+        "tslib": "^1.10.0",
+        "webcrypto-core": "^1.0.14"
+      },
+      "dependencies": {
+        "webcrypto-core": {
+          "version": "1.0.14",
+          "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-1.0.14.tgz",
+          "integrity": "sha512-iGZQcH/o3Jv6mpvCbzan6uAcUcLTTnUCil6RVYakcNh5/QXIKRRC06EFxHru9lHgVKucZy3gG4OBiup0IsOr0g==",
+          "optional": true,
+          "requires": {
+            "pvtsutils": "^1.0.4",
+            "tslib": "^1.10.0"
+          }
+        }
+      }
+    },
+    "@types/node": {
+      "version": "10.14.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.18.tgz",
+      "integrity": "sha512-ryO3Q3++yZC/+b8j8BdKd/dn9JlzlHBPdm80656xwYUdmPkpTGTjkAdt6BByiNupGPE8w0FhBgvYy/fX9hRNGQ=="
+    },
     "addressparser": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-0.3.2.tgz",
@@ -16,11 +66,49 @@
       "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
       "dev": true
     },
+    "ansi-colors": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
+      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
     "arraybuffer.slice": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
       "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco=",
       "dev": true
+    },
+    "asn1js": {
+      "version": "2.0.26",
+      "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-2.0.26.tgz",
+      "integrity": "sha512-yG89F0j9B4B0MKIcFyWWxnpZPLaNTjCj4tkE3fjbAoo0qmpGw0PYYqSbX/4ebnd9Icn8ZgK4K1fvDyEtW1JYtQ==",
+      "requires": {
+        "pvutils": "^1.0.17"
+      }
     },
     "async-limiter": {
       "version": "1.0.0",
@@ -129,10 +217,64 @@
       "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
       "dev": true
     },
-    "commander": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+    "camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "dependencies": {
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "cliui": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+      "dev": true,
+      "requires": {
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
+        "wrap-ansi": "^2.0.0"
+      }
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
     "component-bind": {
@@ -165,6 +307,43 @@
       "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
       "dev": true
     },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "debug": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+      "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "dev": true,
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -196,6 +375,21 @@
         "emailjs-base64": "^1.1.4",
         "ramda": "^0.26.1",
         "text-encoding": "^0.7.0"
+      }
+    },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
       }
     },
     "engine.io": {
@@ -322,10 +516,45 @@
         "wtf-8": "1.0.0"
       }
     },
+    "es-abstract": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.2.tgz",
+      "integrity": "sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "^1.2.0",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.0",
+        "is-callable": "^1.1.4",
+        "is-regex": "^1.0.4",
+        "object-inspect": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "string.prototype.trimleft": "^2.0.0",
+        "string.prototype.trimright": "^2.0.0"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
+      "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+      "dev": true,
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
+      }
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
     "events": {
@@ -334,16 +563,70 @@
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "dev": true
     },
+    "execa": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
+    },
+    "find-up": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^3.0.0"
+      }
+    },
+    "flat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
+      "integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+      "dev": true,
+      "requires": {
+        "is-buffer": "~2.0.3"
+      }
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true
+    },
+    "get-stream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
+      }
+    },
     "glob": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-      "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -359,6 +642,15 @@
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
+    },
+    "has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
     },
     "has-binary": {
       "version": "0.1.7",
@@ -389,10 +681,16 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
+    },
     "he": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
-      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
     "ieee754": {
@@ -418,9 +716,15 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "invert-kv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
       "dev": true
     },
     "ip": {
@@ -429,16 +733,70 @@
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
       "dev": true
     },
+    "is-buffer": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+      "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
       "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
       "dev": true
     },
+    "is-regex": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.1"
+      }
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
+    },
+    "is-symbol": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "dev": true,
+      "requires": {
+        "has-symbols": "^1.0.0"
+      }
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
     },
     "jmespath": {
@@ -447,17 +805,75 @@
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
       "dev": true
     },
+    "js-yaml": {
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
     "json3": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
       "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
       "dev": true
     },
+    "lcid": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+      "dev": true,
+      "requires": {
+        "invert-kv": "^2.0.0"
+      }
+    },
+    "locate-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      }
+    },
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
       "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
       "dev": true
+    },
+    "log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.1"
+      }
+    },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dev": true,
+      "requires": {
+        "p-defer": "^1.0.0"
+      }
+    },
+    "mem": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+      "dev": true,
+      "requires": {
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^2.0.0",
+        "p-is-promise": "^2.0.0"
+      }
     },
     "mime-db": {
       "version": "1.33.0",
@@ -474,6 +890,12 @@
         "mime-db": "~1.33.0"
       }
     },
+    "mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -486,57 +908,54 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
     },
     "mocha": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
-      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.0.tgz",
+      "integrity": "sha512-qwfFgY+7EKAAUAdv7VYMZQknI7YJSGesxHyhn6qD52DV8UcSZs5XwCifcZGMVIE4a5fbmhvbotxC0DLQ0oKohQ==",
       "dev": true,
       "requires": {
+        "ansi-colors": "3.2.3",
         "browser-stdout": "1.3.1",
-        "commander": "2.15.1",
-        "debug": "3.1.0",
+        "debug": "3.2.6",
         "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
-        "glob": "7.1.2",
+        "find-up": "3.0.0",
+        "glob": "7.1.3",
         "growl": "1.10.5",
-        "he": "1.1.1",
+        "he": "1.2.0",
+        "js-yaml": "3.13.1",
+        "log-symbols": "2.2.0",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
-        "supports-color": "5.4.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
+        "ms": "2.1.1",
+        "node-environment-flags": "1.0.5",
+        "object.assign": "4.1.0",
+        "strip-json-comments": "2.0.1",
+        "supports-color": "6.0.0",
+        "which": "1.3.1",
+        "wide-align": "1.1.3",
+        "yargs": "13.2.2",
+        "yargs-parser": "13.0.0",
+        "yargs-unparser": "1.5.0"
       }
     },
     "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
       "dev": true
-    },
-    "nan": {
-      "version": "2.14.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
-      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
-      "optional": true
     },
     "negotiator": {
       "version": "0.6.1",
@@ -544,17 +963,36 @@
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
       "dev": true
     },
-    "node-webcrypto-ossl": {
-      "version": "1.0.47",
-      "resolved": "https://registry.npmjs.org/node-webcrypto-ossl/-/node-webcrypto-ossl-1.0.47.tgz",
-      "integrity": "sha512-73q5ClXxhr7c1LE5dYajdnCVAPr0dhceX/qkATmJGQWyn7xTLgW9s727Bep/6JPqdnx5v7aBraPc+1c2nqjctw==",
-      "optional": true,
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "node-environment-flags": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.5.tgz",
+      "integrity": "sha512-VNYPRfGfmZLx0Ye20jWzHUjyTW/c+6Wq+iLhDzUI4XmhrDd9l/FozXV3F2xOaXjvp0co0+v1YSR3CMP6g+VvLQ==",
+      "dev": true,
       "requires": {
-        "mkdirp": "^0.5.1",
-        "nan": "^2.13.2",
-        "tslib": "^1.9.3",
-        "webcrypto-core": "^0.1.26"
+        "object.getownpropertydescriptors": "^2.0.3",
+        "semver": "^5.7.0"
       }
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.0",
@@ -567,6 +1005,40 @@
       "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
       "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
       "dev": true
+    },
+    "object-inspect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ==",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
+      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.2",
+        "es-abstract": "^1.5.1"
+      }
     },
     "once": {
       "version": "1.4.0",
@@ -581,6 +1053,59 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
       "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8=",
+      "dev": true
+    },
+    "os-locale": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+      "dev": true,
+      "requires": {
+        "execa": "^1.0.0",
+        "lcid": "^2.0.0",
+        "mem": "^4.0.0"
+      }
+    },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "dev": true
+    },
+    "p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+      "dev": true
+    },
+    "p-limit": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+      "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.0.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true
     },
     "panic-client": {
@@ -653,10 +1178,22 @@
         "better-assert": "~1.0.0"
       }
     },
+    "path-exists": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+      "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+      "dev": true
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
     },
     "platform": {
@@ -665,11 +1202,35 @@
       "integrity": "sha1-SSIQiSM1vTExwKCN2i2T7DVD5CM=",
       "dev": true
     },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
       "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
       "dev": true
+    },
+    "pvtsutils": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/pvtsutils/-/pvtsutils-1.0.6.tgz",
+      "integrity": "sha512-0yNrOdJyLE7FZzmeEHTKanwBr5XbmDAd020cKa4ZiTYuGMBYBZmq7vHOhcOqhVllh6gghDBbaz1lnVdOqiB7cw==",
+      "requires": {
+        "@types/node": "^10.14.17",
+        "tslib": "^1.10.0"
+      }
+    },
+    "pvutils": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.0.17.tgz",
+      "integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ=="
     },
     "querystring": {
       "version": "0.2.0",
@@ -683,10 +1244,55 @@
       "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==",
       "optional": true
     },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+      "dev": true
+    },
+    "require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "dev": true
+    },
     "sax": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
     },
     "socket.io": {
@@ -831,10 +1437,67 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
     },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      }
+    },
+    "strip-eof": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
     "supports-color": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
+      "integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
@@ -855,8 +1518,7 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-      "optional": true
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "uglify-js": {
       "version": "3.3.24",
@@ -892,13 +1554,75 @@
       "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
       "dev": true
     },
-    "webcrypto-core": {
-      "version": "0.1.26",
-      "resolved": "https://registry.npmjs.org/webcrypto-core/-/webcrypto-core-0.1.26.tgz",
-      "integrity": "sha512-BZVgJZkkHyuz8loKvsaOKiBDXDpmMZf5xG4QAOlSeYdXlFUl9c1FRrVnAXcOdb4fTHMG+TRu81odJwwSfKnWTA==",
-      "optional": true,
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
       "requires": {
-        "tslib": "^1.7.1"
+        "isexe": "^2.0.0"
+      }
+    },
+    "which-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+      "dev": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "dev": true,
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        }
       }
     },
     "wrappy": {
@@ -945,6 +1669,130 @@
       "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
       "integrity": "sha1-GFqIjATspGw+QHDZn3tJ3jUomS0=",
       "dev": true
+    },
+    "y18n": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
+    },
+    "yargs": {
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
+      "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
+      "dev": true,
+      "requires": {
+        "cliui": "^4.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "os-locale": "^3.1.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^3.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
+      "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      }
+    },
+    "yargs-unparser": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.5.0.tgz",
+      "integrity": "sha512-HK25qidFTCVuj/D1VfNiEndpLIeJN78aqgR23nL3y4N0U/91cOAzqfHlF8n2BvoNDcZmJKin3ddNSvOxSr8flw==",
+      "dev": true,
+      "requires": {
+        "flat": "^4.1.0",
+        "lodash": "^4.17.11",
+        "yargs": "^12.0.5"
+      },
+      "dependencies": {
+        "get-caller-file": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+          "dev": true
+        },
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "12.0.5",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
+          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.2.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^3.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1 || ^4.0.0",
+            "yargs-parser": "^11.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "11.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
+          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
+        }
+      }
     },
     "yeast": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -54,14 +54,14 @@
     "ws": "~>7.1.0"
   },
   "optionalDependencies": {
-    "text-encoding": "^0.7.0",
-    "node-webcrypto-ossl": "^1.0.47",
-    "emailjs": "^2.2.0"
+    "@peculiar/webcrypto": "^1.0.19",
+    "emailjs": "^2.2.0",
+    "text-encoding": "^0.7.0"
   },
   "devDependencies": {
     "aws-sdk": ">=2.153.0",
     "ip": "^1.1.5",
-    "mocha": "^5.2.0",
+    "mocha": "^6.2.0",
     "panic-manager": "^1.2.0",
     "panic-server": "^1.1.1",
     "uglify-js": ">=2.8.22"

--- a/sea.js
+++ b/sea.js
@@ -64,11 +64,6 @@
           (_, i) => String.fromCharCode(this[ i + start])
         ).join('')
       }
-
-      function btoa(b) {
-        return new Buffer(b).toString('base64');
-    };
- 
       if (enc === 'base64') {
         return btoa(this)
       }
@@ -96,9 +91,6 @@
         }
         const input = arguments[0]
         let buf
-        function atob(a) {
-          return new Buffer(a, 'base64').toString('binary');
-      };
         if (typeof input === 'string') {
           const enc = arguments[1] || 'utf8'
           if (enc === 'hex') {
@@ -182,7 +174,7 @@
         random: (len) => Buffer.from(crypto.randomBytes(len))
       });
       //try{
-        const { Crypto: WebCrypto } = USE('@peculiar/webcrypto', 1);
+        const WebCrypto = USE('node-webcrypto-ossl', 1);
         api.ossl = api.subtle = new WebCrypto({directory: 'ossl'}).subtle // ECDH
       //}catch(e){
         //console.log("node-webcrypto-ossl is optionally needed for ECDH, please install if needed.");
@@ -312,6 +304,7 @@
 
     //SEA.pair = async (data, proof, cb) => { try {
     SEA.pair = SEA.pair || (async (cb, opt) => { try {
+
       var ecdhSubtle = shim.ossl || shim.subtle;
       // First: ECDSA keys for signing/verifying...
       var sa = await shim.subtle.generateKey(S.ecdsa.pair, true, [ 'sign', 'verify' ])

--- a/sea.js
+++ b/sea.js
@@ -312,7 +312,6 @@
 
     //SEA.pair = async (data, proof, cb) => { try {
     SEA.pair = SEA.pair || (async (cb, opt) => { try {
-      console.log('SHIM', shim)
       var ecdhSubtle = shim.ossl || shim.subtle;
       // First: ECDSA keys for signing/verifying...
       var sa = await shim.subtle.generateKey(S.ecdsa.pair, true, [ 'sign', 'verify' ])

--- a/sea.js
+++ b/sea.js
@@ -17,6 +17,13 @@
   }
   if(typeof module !== "undefined"){ var common = module }
   /* UNBUILD */
+  function atob(a) {
+    return new Buffer(a, 'base64').toString('binary');
+  };
+
+  function btoa(b) {
+    return new Buffer(b).toString('base64');
+  };
 
   ;USE(function(module){
     // Security, Encryption, and Authorization: SEA.js
@@ -174,7 +181,7 @@
         random: (len) => Buffer.from(crypto.randomBytes(len))
       });
       //try{
-        const WebCrypto = USE('node-webcrypto-ossl', 1);
+        const { Crypto: WebCrypto } = USE('@peculiar/webcrypto', 1);
         api.ossl = api.subtle = new WebCrypto({directory: 'ossl'}).subtle // ECDH
       //}catch(e){
         //console.log("node-webcrypto-ossl is optionally needed for ECDH, please install if needed.");

--- a/sea.js
+++ b/sea.js
@@ -64,6 +64,11 @@
           (_, i) => String.fromCharCode(this[ i + start])
         ).join('')
       }
+
+      function btoa(b) {
+        return new Buffer(b).toString('base64');
+    };
+ 
       if (enc === 'base64') {
         return btoa(this)
       }
@@ -91,6 +96,9 @@
         }
         const input = arguments[0]
         let buf
+        function atob(a) {
+          return new Buffer(a, 'base64').toString('binary');
+      };
         if (typeof input === 'string') {
           const enc = arguments[1] || 'utf8'
           if (enc === 'hex') {
@@ -174,7 +182,7 @@
         random: (len) => Buffer.from(crypto.randomBytes(len))
       });
       //try{
-        const WebCrypto = USE('node-webcrypto-ossl', 1);
+        const { Crypto: WebCrypto } = USE('@peculiar/webcrypto', 1);
         api.ossl = api.subtle = new WebCrypto({directory: 'ossl'}).subtle // ECDH
       //}catch(e){
         //console.log("node-webcrypto-ossl is optionally needed for ECDH, please install if needed.");
@@ -304,7 +312,7 @@
 
     //SEA.pair = async (data, proof, cb) => { try {
     SEA.pair = SEA.pair || (async (cb, opt) => { try {
-
+      console.log('SHIM', shim)
       var ecdhSubtle = shim.ossl || shim.subtle;
       // First: ECDSA keys for signing/verifying...
       var sa = await shim.subtle.generateKey(S.ecdsa.pair, true, [ 'sign', 'verify' ])

--- a/sea/array.js
+++ b/sea/array.js
@@ -1,4 +1,6 @@
-
+    function btoa(b) {
+      return new Buffer(b).toString('base64');
+    };
     // This is Array extended to have .toString(['utf8'|'hex'|'base64'])
     function SeaArray() {}
     Object.assign(SeaArray, { from: Array.from })

--- a/sea/array.js
+++ b/sea/array.js
@@ -1,24 +1,29 @@
+// This is Array extended to have .toString(['utf8'|'hex'|'base64'])
+function SeaArray() {}
+Object.assign(SeaArray, { from: Array.from });
+SeaArray.prototype = Object.create(Array.prototype);
+SeaArray.prototype.toString = function(enc, start, end) {
+  enc = enc || "utf8";
+  start = start || 0;
+  const length = this.length;
+  if (enc === "hex") {
+    const buf = new Uint8Array(this);
+    return [...Array(((end && end + 1) || length) - start).keys()]
+      .map(i => buf[i + start].toString(16).padStart(2, "0"))
+      .join("");
+  }
+  if (enc === "utf8") {
+    return Array.from({ length: (end || length) - start }, (_, i) =>
+      String.fromCharCode(this[i + start])
+    ).join("");
+  }
 
-    // This is Array extended to have .toString(['utf8'|'hex'|'base64'])
-    function SeaArray() {}
-    Object.assign(SeaArray, { from: Array.from })
-    SeaArray.prototype = Object.create(Array.prototype)
-    SeaArray.prototype.toString = function(enc, start, end) { enc = enc || 'utf8'; start = start || 0;
-      const length = this.length
-      if (enc === 'hex') {
-        const buf = new Uint8Array(this)
-        return [ ...Array(((end && (end + 1)) || length) - start).keys()]
-        .map((i) => buf[ i + start ].toString(16).padStart(2, '0')).join('')
-      }
-      if (enc === 'utf8') {
-        return Array.from(
-          { length: (end || length) - start },
-          (_, i) => String.fromCharCode(this[ i + start])
-        ).join('')
-      }
-      if (enc === 'base64') {
-        return btoa(this)
-      }
-    }
-    module.exports = SeaArray;
-  
+  function btoa(b) {
+    return new Buffer(b).toString("base64");
+  }
+
+  if (enc === "base64") {
+    return btoa(this);
+  }
+};
+module.exports = SeaArray;

--- a/sea/array.js
+++ b/sea/array.js
@@ -1,29 +1,24 @@
-// This is Array extended to have .toString(['utf8'|'hex'|'base64'])
-function SeaArray() {}
-Object.assign(SeaArray, { from: Array.from });
-SeaArray.prototype = Object.create(Array.prototype);
-SeaArray.prototype.toString = function(enc, start, end) {
-  enc = enc || "utf8";
-  start = start || 0;
-  const length = this.length;
-  if (enc === "hex") {
-    const buf = new Uint8Array(this);
-    return [...Array(((end && end + 1) || length) - start).keys()]
-      .map(i => buf[i + start].toString(16).padStart(2, "0"))
-      .join("");
-  }
-  if (enc === "utf8") {
-    return Array.from({ length: (end || length) - start }, (_, i) =>
-      String.fromCharCode(this[i + start])
-    ).join("");
-  }
 
-  function btoa(b) {
-    return new Buffer(b).toString("base64");
-  }
-
-  if (enc === "base64") {
-    return btoa(this);
-  }
-};
-module.exports = SeaArray;
+    // This is Array extended to have .toString(['utf8'|'hex'|'base64'])
+    function SeaArray() {}
+    Object.assign(SeaArray, { from: Array.from })
+    SeaArray.prototype = Object.create(Array.prototype)
+    SeaArray.prototype.toString = function(enc, start, end) { enc = enc || 'utf8'; start = start || 0;
+      const length = this.length
+      if (enc === 'hex') {
+        const buf = new Uint8Array(this)
+        return [ ...Array(((end && (end + 1)) || length) - start).keys()]
+        .map((i) => buf[ i + start ].toString(16).padStart(2, '0')).join('')
+      }
+      if (enc === 'utf8') {
+        return Array.from(
+          { length: (end || length) - start },
+          (_, i) => String.fromCharCode(this[ i + start])
+        ).join('')
+      }
+      if (enc === 'base64') {
+        return btoa(this)
+      }
+    }
+    module.exports = SeaArray;
+  

--- a/sea/buffer.js
+++ b/sea/buffer.js
@@ -1,78 +1,95 @@
-
-    // This is Buffer implementation used in SEA. Functionality is mostly
-    // compatible with NodeJS 'safe-buffer' and is used for encoding conversions
-    // between binary and 'hex' | 'utf8' | 'base64'
-    // See documentation and validation for safe implementation in:
-    // https://github.com/feross/safe-buffer#update
-    var SeaArray = require('./array');
-    function SafeBuffer(...props) {
-      console.warn('new SafeBuffer() is depreciated, please use SafeBuffer.from()')
-      return SafeBuffer.from(...props)
+// This is Buffer implementation used in SEA. Functionality is mostly
+// compatible with NodeJS 'safe-buffer' and is used for encoding conversions
+// between binary and 'hex' | 'utf8' | 'base64'
+// See documentation and validation for safe implementation in:
+// https://github.com/feross/safe-buffer#update
+var SeaArray = require("./array");
+function SafeBuffer(...props) {
+  console.warn("new SafeBuffer() is depreciated, please use SafeBuffer.from()");
+  return SafeBuffer.from(...props);
+}
+SafeBuffer.prototype = Object.create(Array.prototype);
+Object.assign(SafeBuffer, {
+  // (data, enc) where typeof data === 'string' then enc === 'utf8'|'hex'|'base64'
+  from() {
+    if (!Object.keys(arguments).length) {
+      throw new TypeError(
+        "First argument must be a string, Buffer, ArrayBuffer, Array, or array-like object."
+      );
     }
-    SafeBuffer.prototype = Object.create(Array.prototype)
-    Object.assign(SafeBuffer, {
-      // (data, enc) where typeof data === 'string' then enc === 'utf8'|'hex'|'base64'
-      from() {
-        if (!Object.keys(arguments).length) {
-          throw new TypeError('First argument must be a string, Buffer, ArrayBuffer, Array, or array-like object.')
+    const input = arguments[0];
+    let buf;
+    function atob(a) {
+      return new Buffer(a, "base64").toString("binary");
+    }
+    if (typeof input === "string") {
+      const enc = arguments[1] || "utf8";
+      if (enc === "hex") {
+        const bytes = input
+          .match(/([\da-fA-F]{2})/g)
+          .map(byte => parseInt(byte, 16));
+        if (!bytes || !bytes.length) {
+          throw new TypeError("Invalid first argument for type 'hex'.");
         }
-        const input = arguments[0]
-        let buf
-        if (typeof input === 'string') {
-          const enc = arguments[1] || 'utf8'
-          if (enc === 'hex') {
-            const bytes = input.match(/([\da-fA-F]{2})/g)
-            .map((byte) => parseInt(byte, 16))
-            if (!bytes || !bytes.length) {
-              throw new TypeError('Invalid first argument for type \'hex\'.')
-            }
-            buf = SeaArray.from(bytes)
-          } else if (enc === 'utf8') {
-            const length = input.length
-            const words = new Uint16Array(length)
-            Array.from({ length: length }, (_, i) => words[i] = input.charCodeAt(i))
-            buf = SeaArray.from(words)
-          } else if (enc === 'base64') {
-            const dec = atob(input)
-            const length = dec.length
-            const bytes = new Uint8Array(length)
-            Array.from({ length: length }, (_, i) => bytes[i] = dec.charCodeAt(i))
-            buf = SeaArray.from(bytes)
-          } else if (enc === 'binary') {
-            buf = SeaArray.from(input)
-          } else {
-            console.info('SafeBuffer.from unknown encoding: '+enc)
-          }
-          return buf
-        }
-        const byteLength = input.byteLength // what is going on here? FOR MARTTI
-        const length = input.byteLength ? input.byteLength : input.length
-        if (length) {
-          let buf
-          if (input instanceof ArrayBuffer) {
-            buf = new Uint8Array(input)
-          }
-          return SeaArray.from(buf || input)
-        }
-      },
-      // This is 'safe-buffer.alloc' sans encoding support
-      alloc(length, fill = 0 /*, enc*/ ) {
-        return SeaArray.from(new Uint8Array(Array.from({ length: length }, () => fill)))
-      },
-      // This is normal UNSAFE 'buffer.alloc' or 'new Buffer(length)' - don't use!
-      allocUnsafe(length) {
-        return SeaArray.from(new Uint8Array(Array.from({ length : length })))
-      },
-      // This puts together array of array like members
-      concat(arr) { // octet array
-        if (!Array.isArray(arr)) {
-          throw new TypeError('First argument must be Array containing ArrayBuffer or Uint8Array instances.')
-        }
-        return SeaArray.from(arr.reduce((ret, item) => ret.concat(Array.from(item)), []))
+        buf = SeaArray.from(bytes);
+      } else if (enc === "utf8") {
+        const length = input.length;
+        const words = new Uint16Array(length);
+        Array.from(
+          { length: length },
+          (_, i) => (words[i] = input.charCodeAt(i))
+        );
+        buf = SeaArray.from(words);
+      } else if (enc === "base64") {
+        const dec = atob(input);
+        const length = dec.length;
+        const bytes = new Uint8Array(length);
+        Array.from(
+          { length: length },
+          (_, i) => (bytes[i] = dec.charCodeAt(i))
+        );
+        buf = SeaArray.from(bytes);
+      } else if (enc === "binary") {
+        buf = SeaArray.from(input);
+      } else {
+        console.info("SafeBuffer.from unknown encoding: " + enc);
       }
-    })
-    SafeBuffer.prototype.from = SafeBuffer.from
-    SafeBuffer.prototype.toString = SeaArray.prototype.toString
+      return buf;
+    }
+    const byteLength = input.byteLength; // what is going on here? FOR MARTTI
+    const length = input.byteLength ? input.byteLength : input.length;
+    if (length) {
+      let buf;
+      if (input instanceof ArrayBuffer) {
+        buf = new Uint8Array(input);
+      }
+      return SeaArray.from(buf || input);
+    }
+  },
+  // This is 'safe-buffer.alloc' sans encoding support
+  alloc(length, fill = 0 /*, enc*/) {
+    return SeaArray.from(
+      new Uint8Array(Array.from({ length: length }, () => fill))
+    );
+  },
+  // This is normal UNSAFE 'buffer.alloc' or 'new Buffer(length)' - don't use!
+  allocUnsafe(length) {
+    return SeaArray.from(new Uint8Array(Array.from({ length: length })));
+  },
+  // This puts together array of array like members
+  concat(arr) {
+    // octet array
+    if (!Array.isArray(arr)) {
+      throw new TypeError(
+        "First argument must be Array containing ArrayBuffer or Uint8Array instances."
+      );
+    }
+    return SeaArray.from(
+      arr.reduce((ret, item) => ret.concat(Array.from(item)), [])
+    );
+  }
+});
+SafeBuffer.prototype.from = SafeBuffer.from;
+SafeBuffer.prototype.toString = SeaArray.prototype.toString;
 
-    module.exports = SafeBuffer;
-  
+module.exports = SafeBuffer;

--- a/sea/buffer.js
+++ b/sea/buffer.js
@@ -1,4 +1,6 @@
-
+    function atob(a) {
+      return new Buffer(a, 'base64').toString('binary');
+    };
     // This is Buffer implementation used in SEA. Functionality is mostly
     // compatible with NodeJS 'safe-buffer' and is used for encoding conversions
     // between binary and 'hex' | 'utf8' | 'base64'

--- a/sea/buffer.js
+++ b/sea/buffer.js
@@ -1,95 +1,78 @@
-// This is Buffer implementation used in SEA. Functionality is mostly
-// compatible with NodeJS 'safe-buffer' and is used for encoding conversions
-// between binary and 'hex' | 'utf8' | 'base64'
-// See documentation and validation for safe implementation in:
-// https://github.com/feross/safe-buffer#update
-var SeaArray = require("./array");
-function SafeBuffer(...props) {
-  console.warn("new SafeBuffer() is depreciated, please use SafeBuffer.from()");
-  return SafeBuffer.from(...props);
-}
-SafeBuffer.prototype = Object.create(Array.prototype);
-Object.assign(SafeBuffer, {
-  // (data, enc) where typeof data === 'string' then enc === 'utf8'|'hex'|'base64'
-  from() {
-    if (!Object.keys(arguments).length) {
-      throw new TypeError(
-        "First argument must be a string, Buffer, ArrayBuffer, Array, or array-like object."
-      );
-    }
-    const input = arguments[0];
-    let buf;
-    function atob(a) {
-      return new Buffer(a, "base64").toString("binary");
-    }
-    if (typeof input === "string") {
-      const enc = arguments[1] || "utf8";
-      if (enc === "hex") {
-        const bytes = input
-          .match(/([\da-fA-F]{2})/g)
-          .map(byte => parseInt(byte, 16));
-        if (!bytes || !bytes.length) {
-          throw new TypeError("Invalid first argument for type 'hex'.");
-        }
-        buf = SeaArray.from(bytes);
-      } else if (enc === "utf8") {
-        const length = input.length;
-        const words = new Uint16Array(length);
-        Array.from(
-          { length: length },
-          (_, i) => (words[i] = input.charCodeAt(i))
-        );
-        buf = SeaArray.from(words);
-      } else if (enc === "base64") {
-        const dec = atob(input);
-        const length = dec.length;
-        const bytes = new Uint8Array(length);
-        Array.from(
-          { length: length },
-          (_, i) => (bytes[i] = dec.charCodeAt(i))
-        );
-        buf = SeaArray.from(bytes);
-      } else if (enc === "binary") {
-        buf = SeaArray.from(input);
-      } else {
-        console.info("SafeBuffer.from unknown encoding: " + enc);
-      }
-      return buf;
-    }
-    const byteLength = input.byteLength; // what is going on here? FOR MARTTI
-    const length = input.byteLength ? input.byteLength : input.length;
-    if (length) {
-      let buf;
-      if (input instanceof ArrayBuffer) {
-        buf = new Uint8Array(input);
-      }
-      return SeaArray.from(buf || input);
-    }
-  },
-  // This is 'safe-buffer.alloc' sans encoding support
-  alloc(length, fill = 0 /*, enc*/) {
-    return SeaArray.from(
-      new Uint8Array(Array.from({ length: length }, () => fill))
-    );
-  },
-  // This is normal UNSAFE 'buffer.alloc' or 'new Buffer(length)' - don't use!
-  allocUnsafe(length) {
-    return SeaArray.from(new Uint8Array(Array.from({ length: length })));
-  },
-  // This puts together array of array like members
-  concat(arr) {
-    // octet array
-    if (!Array.isArray(arr)) {
-      throw new TypeError(
-        "First argument must be Array containing ArrayBuffer or Uint8Array instances."
-      );
-    }
-    return SeaArray.from(
-      arr.reduce((ret, item) => ret.concat(Array.from(item)), [])
-    );
-  }
-});
-SafeBuffer.prototype.from = SafeBuffer.from;
-SafeBuffer.prototype.toString = SeaArray.prototype.toString;
 
-module.exports = SafeBuffer;
+    // This is Buffer implementation used in SEA. Functionality is mostly
+    // compatible with NodeJS 'safe-buffer' and is used for encoding conversions
+    // between binary and 'hex' | 'utf8' | 'base64'
+    // See documentation and validation for safe implementation in:
+    // https://github.com/feross/safe-buffer#update
+    var SeaArray = require('./array');
+    function SafeBuffer(...props) {
+      console.warn('new SafeBuffer() is depreciated, please use SafeBuffer.from()')
+      return SafeBuffer.from(...props)
+    }
+    SafeBuffer.prototype = Object.create(Array.prototype)
+    Object.assign(SafeBuffer, {
+      // (data, enc) where typeof data === 'string' then enc === 'utf8'|'hex'|'base64'
+      from() {
+        if (!Object.keys(arguments).length) {
+          throw new TypeError('First argument must be a string, Buffer, ArrayBuffer, Array, or array-like object.')
+        }
+        const input = arguments[0]
+        let buf
+        if (typeof input === 'string') {
+          const enc = arguments[1] || 'utf8'
+          if (enc === 'hex') {
+            const bytes = input.match(/([\da-fA-F]{2})/g)
+            .map((byte) => parseInt(byte, 16))
+            if (!bytes || !bytes.length) {
+              throw new TypeError('Invalid first argument for type \'hex\'.')
+            }
+            buf = SeaArray.from(bytes)
+          } else if (enc === 'utf8') {
+            const length = input.length
+            const words = new Uint16Array(length)
+            Array.from({ length: length }, (_, i) => words[i] = input.charCodeAt(i))
+            buf = SeaArray.from(words)
+          } else if (enc === 'base64') {
+            const dec = atob(input)
+            const length = dec.length
+            const bytes = new Uint8Array(length)
+            Array.from({ length: length }, (_, i) => bytes[i] = dec.charCodeAt(i))
+            buf = SeaArray.from(bytes)
+          } else if (enc === 'binary') {
+            buf = SeaArray.from(input)
+          } else {
+            console.info('SafeBuffer.from unknown encoding: '+enc)
+          }
+          return buf
+        }
+        const byteLength = input.byteLength // what is going on here? FOR MARTTI
+        const length = input.byteLength ? input.byteLength : input.length
+        if (length) {
+          let buf
+          if (input instanceof ArrayBuffer) {
+            buf = new Uint8Array(input)
+          }
+          return SeaArray.from(buf || input)
+        }
+      },
+      // This is 'safe-buffer.alloc' sans encoding support
+      alloc(length, fill = 0 /*, enc*/ ) {
+        return SeaArray.from(new Uint8Array(Array.from({ length: length }, () => fill)))
+      },
+      // This is normal UNSAFE 'buffer.alloc' or 'new Buffer(length)' - don't use!
+      allocUnsafe(length) {
+        return SeaArray.from(new Uint8Array(Array.from({ length : length })))
+      },
+      // This puts together array of array like members
+      concat(arr) { // octet array
+        if (!Array.isArray(arr)) {
+          throw new TypeError('First argument must be Array containing ArrayBuffer or Uint8Array instances.')
+        }
+        return SeaArray.from(arr.reduce((ret, item) => ret.concat(Array.from(item)), []))
+      }
+    })
+    SafeBuffer.prototype.from = SafeBuffer.from
+    SafeBuffer.prototype.toString = SeaArray.prototype.toString
+
+    module.exports = SafeBuffer;
+  

--- a/sea/shim.js
+++ b/sea/shim.js
@@ -1,36 +1,39 @@
+const SEA = require("./root");
+const Buffer = require("./buffer");
+const api = { Buffer: Buffer };
+var o = {};
 
-    const SEA = require('./root')
-    const Buffer = require('./buffer')
-    const api = {Buffer: Buffer}
-    var o = {};
+if (SEA.window) {
+  api.crypto = window.crypto || window.msCrypto;
+  api.subtle = (api.crypto || o).subtle || (api.crypto || o).webkitSubtle;
+  api.TextEncoder = window.TextEncoder;
+  api.TextDecoder = window.TextDecoder;
+  api.random = len =>
+    Buffer.from(api.crypto.getRandomValues(new Uint8Array(Buffer.alloc(len))));
+}
+if (!api.crypto) {
+  try {
+    var crypto = require("crypto", 1);
+    const { TextEncoder, TextDecoder } = require("text-encoding", 1);
+    Object.assign(api, {
+      crypto,
+      //subtle,
+      TextEncoder,
+      TextDecoder,
+      random: len => Buffer.from(crypto.randomBytes(len))
+    });
+    //try{
+    const { Crypto: WebCrypto } = require("@peculiar/webcrypto", 1);
+    api.ossl = api.subtle = new WebCrypto({ directory: "ossl" }).subtle; // ECDH
+    //}catch(e){
+    //console.log("node-webcrypto-ossl is optionally needed for ECDH, please install if needed.");
+    //}
+  } catch (e) {
+    console.log(
+      "node-webcrypto-ossl and text-encoding may not be included by default, please add it to your package.json!"
+    );
+    OSSL_WEBCRYPTO_OR_TEXT_ENCODING_NOT_INSTALLED;
+  }
+}
 
-    if(SEA.window){
-      api.crypto = window.crypto || window.msCrypto;
-      api.subtle = (api.crypto||o).subtle || (api.crypto||o).webkitSubtle;
-      api.TextEncoder = window.TextEncoder;
-      api.TextDecoder = window.TextDecoder;
-      api.random = (len) => Buffer.from(api.crypto.getRandomValues(new Uint8Array(Buffer.alloc(len))))
-    }
-    if(!api.crypto){try{
-      var crypto = require('crypto', 1);
-      const { TextEncoder, TextDecoder } = require('text-encoding', 1)
-      Object.assign(api, {
-        crypto,
-        //subtle,
-        TextEncoder,
-        TextDecoder,
-        random: (len) => Buffer.from(crypto.randomBytes(len))
-      });
-      //try{
-        const WebCrypto = require('node-webcrypto-ossl', 1);
-        api.ossl = api.subtle = new WebCrypto({directory: 'ossl'}).subtle // ECDH
-      //}catch(e){
-        //console.log("node-webcrypto-ossl is optionally needed for ECDH, please install if needed.");
-      //}
-    }catch(e){
-      console.log("node-webcrypto-ossl and text-encoding may not be included by default, please add it to your package.json!");
-      OSSL_WEBCRYPTO_OR_TEXT_ENCODING_NOT_INSTALLED;
-    }}
-
-    module.exports = api
-  
+module.exports = api;

--- a/sea/shim.js
+++ b/sea/shim.js
@@ -1,39 +1,36 @@
-const SEA = require("./root");
-const Buffer = require("./buffer");
-const api = { Buffer: Buffer };
-var o = {};
 
-if (SEA.window) {
-  api.crypto = window.crypto || window.msCrypto;
-  api.subtle = (api.crypto || o).subtle || (api.crypto || o).webkitSubtle;
-  api.TextEncoder = window.TextEncoder;
-  api.TextDecoder = window.TextDecoder;
-  api.random = len =>
-    Buffer.from(api.crypto.getRandomValues(new Uint8Array(Buffer.alloc(len))));
-}
-if (!api.crypto) {
-  try {
-    var crypto = require("crypto", 1);
-    const { TextEncoder, TextDecoder } = require("text-encoding", 1);
-    Object.assign(api, {
-      crypto,
-      //subtle,
-      TextEncoder,
-      TextDecoder,
-      random: len => Buffer.from(crypto.randomBytes(len))
-    });
-    //try{
-    const { Crypto: WebCrypto } = require("@peculiar/webcrypto", 1);
-    api.ossl = api.subtle = new WebCrypto({ directory: "ossl" }).subtle; // ECDH
-    //}catch(e){
-    //console.log("node-webcrypto-ossl is optionally needed for ECDH, please install if needed.");
-    //}
-  } catch (e) {
-    console.log(
-      "node-webcrypto-ossl and text-encoding may not be included by default, please add it to your package.json!"
-    );
-    OSSL_WEBCRYPTO_OR_TEXT_ENCODING_NOT_INSTALLED;
-  }
-}
+    const SEA = require('./root')
+    const Buffer = require('./buffer')
+    const api = {Buffer: Buffer}
+    var o = {};
 
-module.exports = api;
+    if(SEA.window){
+      api.crypto = window.crypto || window.msCrypto;
+      api.subtle = (api.crypto||o).subtle || (api.crypto||o).webkitSubtle;
+      api.TextEncoder = window.TextEncoder;
+      api.TextDecoder = window.TextDecoder;
+      api.random = (len) => Buffer.from(api.crypto.getRandomValues(new Uint8Array(Buffer.alloc(len))))
+    }
+    if(!api.crypto){try{
+      var crypto = require('crypto', 1);
+      const { TextEncoder, TextDecoder } = require('text-encoding', 1)
+      Object.assign(api, {
+        crypto,
+        //subtle,
+        TextEncoder,
+        TextDecoder,
+        random: (len) => Buffer.from(crypto.randomBytes(len))
+      });
+      //try{
+        const WebCrypto = require('node-webcrypto-ossl', 1);
+        api.ossl = api.subtle = new WebCrypto({directory: 'ossl'}).subtle // ECDH
+      //}catch(e){
+        //console.log("node-webcrypto-ossl is optionally needed for ECDH, please install if needed.");
+      //}
+    }catch(e){
+      console.log("node-webcrypto-ossl and text-encoding may not be included by default, please add it to your package.json!");
+      OSSL_WEBCRYPTO_OR_TEXT_ENCODING_NOT_INSTALLED;
+    }}
+
+    module.exports = api
+  

--- a/sea/shim.js
+++ b/sea/shim.js
@@ -22,7 +22,7 @@
         random: (len) => Buffer.from(crypto.randomBytes(len))
       });
       //try{
-        const WebCrypto = require('node-webcrypto-ossl', 1);
+        const { Crypto: WebCrypto } = USE('@peculiar/webcrypto', 1);
         api.ossl = api.subtle = new WebCrypto({directory: 'ossl'}).subtle // ECDH
       //}catch(e){
         //console.log("node-webcrypto-ossl is optionally needed for ECDH, please install if needed.");

--- a/test/sea/sea.js
+++ b/test/sea/sea.js
@@ -1,5 +1,8 @@
 var root;
 var Gun;
+function atob(a) {
+  return new Buffer(a, 'base64').toString('binary');
+};
 (function(){
   var env;
   if(typeof global !== 'undefined'){ env = global }


### PR DESCRIPTION
## Addresses #801 

## Changes
- Removed `node-webcrypto-ossl` optional dependency
- Added `@peculiar/webcrypto`
- Naively patched missing `atob` and `btoa` functions to get tests passing

## Test Suite
<img width="637" alt="Screen Shot 2019-09-14 at 1 04 18 PM" src="https://user-images.githubusercontent.com/1007233/64913171-315a3000-d6f0-11e9-9996-66b5df0b94fa.png">

## Notes
- I got a few spec failures due to `atob` and `btoa` missing outside of the browser environment. 
I quickly patched them using this [gist](https://gist.github.com/jmshal/b14199f7402c8f3a4568733d8bed0f25). Let me know if there's another pattern you'd like for me to follow for polyfilling these functions.
- The test suite fails in Node.js:8 with `TypeError: crypto__default.generateKeyPairSync is not a function`. This function -- introduced by `webcrypto` -- was added to `Node@10.12.0`