### PR TITLE
Windows 10 in multicasting fix

### DIFF
--- a/lib/multicast.js
+++ b/lib/multicast.js
@@ -19,7 +19,11 @@ Gun.on('create', function(root){
 
   try{ dgram = require("dgram") }catch(e){ return }
   var socket = dgram.createSocket({type: "udp4", reuseAddr: true});
-  socket.bind(udp.port);
+  socket.bind({port: udp.port, exclusive: true}, function(){
+    socket.setBroadcast(true);
+    socket.setMulticastTTL(128);
+    socket.addMembership(udp.address);
+  });
 
   socket.on("listening", function(){
     try { socket.addMembership(udp.address) }catch(e){ return }


### PR DESCRIPTION
As described in #787 this should fix the error on GUN `npm start` on Windows 10.  
There were no errors in `npm test`, or anything indicating something broke,  
but there's also been no manual testing, maybe @mmalmi can help out on this.