### PR TITLE
multicast fix

### DIFF
--- a/lib/multicast.js
+++ b/lib/multicast.js
@@ -22,11 +22,10 @@ Gun.on('create', function(root){
   socket.bind({port: udp.port, exclusive: true}, function(){
     socket.setBroadcast(true);
     socket.setMulticastTTL(128);
-    try{ socket.addMembership(udp.address); }catch(e){}
   });
 
   socket.on("listening", function(){
-    try { socket.addMembership(udp.address) }catch(e){ return }
+    try { socket.addMembership(udp.address) }catch(e){ console.error(e); return; }
     udp.peer = {id: udp.address + ':' + udp.port, wire: socket};
 
     udp.peer.say = function(raw){
@@ -60,7 +59,7 @@ Gun.on('create', function(root){
 
     var url = 'http://' + info.address + ':' + (port || (opt.web && opt.web.address()||{}).port) + '/gun';
     if(root.opt.peers[url]){ return }
-  
+
     //console.log('discovered', url, message, info);
     root.$.opt(url);
 


### PR DESCRIPTION
Remove duplicate `socket.addMembership(udp.address);` and multicast works again (osx).