### PR TITLE
webrtc defaults messing at least firefox

### DIFF
--- a/lib/webrtc.js
+++ b/lib/webrtc.js
@@ -21,13 +21,16 @@
 		opt.RTCSessionDescription = rtcsd;
 		opt.RTCIceCandidate = rtcic;
 		opt.rtc = opt.rtc || {'iceServers': [
-      {url: 'stun:stun.l.google.com:19302'},
-      {url: "stun:stun.sipgate.net:3478"},
-      {url: "stun:stun.stunprotocol.org"},
-      {url: "stun:stun.sipgate.net:10000"},
-      {url: "stun:217.10.68.152:10000"},
-      {url: 'stun:stun.services.mozilla.com'} 
+      {urls: 'stun:stun.l.google.com:19302'},
+      {urls: "stun:stun.sipgate.net:3478"}/*,
+      {urls: "stun:stun.stunprotocol.org"},
+      {urls: "stun:stun.sipgate.net:10000"},
+      {urls: "stun:217.10.68.152:10000"},
+      {urls: 'stun:stun.services.mozilla.com'}*/ 
     ]};
+    // TODO: Select the most appropriate stuns. 
+    // FIXME: Find the wire throwing ICE Failed
+    // The above change corrects at least firefox RTC Peer handler where it **throws** on over 6 ice servers, and updates url: to urls: removing deprecation warning 
     opt.rtc.dataChannel = opt.rtc.dataChannel || {ordered: false, maxRetransmits: 2};
     opt.rtc.sdp = opt.rtc.sdp || {mandatory: {OfferToReceiveAudio: false, OfferToReceiveVideo: false}};
     opt.announce = function(to){


### PR DESCRIPTION
Updated some spec deprecations and removed some iceServers to prevent firefox throwing errors and avoiding console.warns see: https://github.com/jabis/gun/commit/b3f87b180ec228b2730c91e908850cb76b2b699e