### PR TITLE
user.recall callback always executed

### DIFF
--- a/sea.js
+++ b/sea.js
@@ -3,7 +3,7 @@
   /* UNBUILD */
   var root;
   if(typeof window !== "undefined"){ root = window }
-  
+
   if(typeof global !== "undefined"){ root = global }
   root = root || {};
   var console = root.console || {log: function(){}};
@@ -187,7 +187,7 @@
       Object.assign(api, {
         crypto,
         random: (len) => Buffer.from(crypto.randomBytes(len))
-      });      
+      });
       const isocrypto = require('isomorphic-webcrypto');
       api.ossl = api.subtle = isocrypto.subtle;
     }catch(e){
@@ -218,7 +218,7 @@
       if(d){ jwk.d = d }
       return jwk;
     };
-    
+
     s.keyToJwk = function(keyBytes) {
       const keyB64 = keyBytes.toString('base64');
       const k = keyB64.replace(/\+/g, '-').replace(/\//g, '_').replace(/\=/g, '');
@@ -293,7 +293,7 @@
       var r = shim.Buffer.from(work, 'binary').toString(opt.encode || 'base64')
       if(cb){ try{ cb(r) }catch(e){console.log(e)} }
       return r;
-    } catch(e) { 
+    } catch(e) {
       console.log(e);
       SEA.err = e;
       if(SEA.throw){ throw e }
@@ -339,7 +339,7 @@
         // but split on a non-base64 letter.
         return key;
       })
-      
+
       // To include PGPv4 kind of keyId:
       // const pubId = await SEA.keyid(keys.pub)
       // Next: ECDH keys for encryption/decryption...
@@ -508,8 +508,8 @@
       var opt = opt || {};
       const combo = key + (salt || shim.random(8)).toString('utf8'); // new
       const hash = shim.Buffer.from(await sha256hash(combo), 'binary')
-      
-      const jwkKey = S.keyToJwk(hash)      
+
+      const jwkKey = S.keyToJwk(hash)
       return await shim.subtle.importKey('jwk', jwkKey, {name:'AES-GCM'}, false, ['encrypt', 'decrypt'])
     }
     module.exports = importGen;
@@ -544,7 +544,7 @@
 
       if(cb){ try{ cb(r) }catch(e){console.log(e)} }
       return r;
-    } catch(e) { 
+    } catch(e) {
       console.log(e);
       SEA.err = e;
       if(SEA.throw){ throw e }
@@ -586,7 +586,7 @@
       var r = S.parse(new shim.TextDecoder('utf8').decode(ct));
       if(cb){ try{ cb(r) }catch(e){console.log(e)} }
       return r;
-    } catch(e) { 
+    } catch(e) {
       console.log(e);
       SEA.err = e;
       if(SEA.throw){ throw e }
@@ -601,7 +601,7 @@
     var SEA = USE('./root');
     var shim = USE('./shim');
     var S = USE('./settings');
-    // Derive shared secret from other's pub and my epub/epriv 
+    // Derive shared secret from other's pub and my epub/epriv
     SEA.secret = SEA.secret || (async (key, pair, cb, opt) => { try {
       opt = opt || {};
       if(!pair || !pair.epriv || !pair.epub){
@@ -723,7 +723,7 @@
     var Gun = SEA.Gun;
     var then = USE('./then');
 
-    function User(root){ 
+    function User(root){
       this._ = {$: this};
     }
     User.prototype = (function(){ function F(){}; F.prototype = Gun.chain; return new F() }()) // Object.create polyfill
@@ -804,11 +804,11 @@
         act.e();
       }
       act.e = function(){
-        act.data.epub = act.pair.epub; 
+        act.data.epub = act.pair.epub;
         SEA.encrypt({priv: act.pair.priv, epriv: act.pair.epriv}, act.proof, act.f, {raw:1}); // to keep the private key safe, we AES encrypt it with the proof of work!
       }
       act.f = function(auth){
-        act.data.auth = JSON.stringify({ek: auth, s: act.salt}); 
+        act.data.auth = JSON.stringify({ek: auth, s: act.salt});
         act.g(act.data.auth);
       }
       act.g = function(auth){ var tmp;
@@ -850,7 +850,7 @@
         var get = (act.list = (act.list||[]).concat(list||[])).shift();
         if(u === get){
           if(act.name){ return act.err('Your user account is not published for dApps to access, please consider syncing it online, or allowing local access by adding your device as a peer.') }
-          return act.err('Wrong user or password.') 
+          return act.err('Wrong user or password.')
         }
         root.get(get).once(act.a);
       }
@@ -1008,9 +1008,15 @@
               root.user().auth(sS.alias, sS.tmp, cb);
             }
           }
-          }catch(e){}
+          } catch(e){
+            if (typeof cb === 'function') {
+              cb({ err: e});
+            }
+          }
         }
         return gun;
+      } else if (typeof cb === 'function') {
+        cb({ err: 'user not found in sessionStorage'})
       }
       /*
         TODO: copy mhelander's expiry code back in.


### PR DESCRIPTION
I believe user.recall should always execute the passed-in callback. I would like to use it like this in a React AuthProvider:
```Javascript
useEffect(() => {
    const noUserState = { status: 'success', user: null, createUser, authenticate };
    user.recall({ sessionStorage: true }, resp => {
      if (resp.err) setState(noUserState);
      else if (!resp) setState({ noUserState });
      else setState({ status: 'success', user, logout });
    });
  }, []);
```
To do so, user.recall needs to fire the callback. 

I don't know about how to unbuild sea. I looked at /lib/unbuild.js and tried unsuccessfully to modify it. I also can't get the tests the sea tests to run so I couldn't write tests. npm run seatest throws an error. 

I found the entire unbuild process very confusing. 