### PR TITLE
Allow externally provided websockets in constructor

### DIFF
--- a/lib/ws.js
+++ b/lib/ws.js
@@ -19,7 +19,7 @@ Gun.on('opt', function mount(ctx){
 		ws.server = ws.server || opt.web;
 		ws.path = ws.path || '/gun';
 
-		ws.web = new WebSocket.Server(ws);
+		if (!ws.web) ws.web = new WebSocket.Server(ws);
 
 		ws.web.on('connection', function(wire){
 			wire.upgradeReq = wire.upgradeReq || {};


### PR DESCRIPTION
For consideration (this can also be overloaded in stock gun)
The current ws.js code does not allow providing an external websocket while initializing Gun. This one line patch makes it possible. Additional checks might be suitable to determine if the passed object is actually a websocket, etc.

```
        var myWS= new WebSocket.Server({ noServer: true, path: pathname});
        var myGun = new Gun({ 
            ws: { noServer: true, path: '/mygun', web: myWS }, 
            web: myWS 
        });
```