### PR TITLE
Fix for ES Modules when using a peer

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,12 +231,14 @@ now --npm amark/gun
 
 Then visit the URL in the output of the 'now --npm' step, in your browser.
 
-### [Unebo](https://unubo.app/)
+### [Unubo](https://unubo.app/)
 
-Fork this GUN repo (Unebo only deploys from your own GitHub repo's).  
-Add a Node.js app, select your GUN fork, set `npm start` start as the command and deploy.
+Fork this GUN repo (Unubo only deploys from your own GitHub repo's).  
+Add a Node.js app, select your GUN fork, set `npm start` start as the command and deploy. 
 
-Then visit the deployed app by following the 'view app' button, in your browser.
+From the experience of [genderev](https://github.com/genderev), this only works if you set your country to the United States.
+
+Visit the deployed app by following the 'view app' button, in your browser.
 
 ### [Docker](https://www.docker.com/)
 

--- a/gun.js
+++ b/gun.js
@@ -987,7 +987,7 @@
 		if(typeof window !== "undefined"){ (window.GUN = window.Gun = Gun).window = window }
 		try{ if(typeof MODULE !== "undefined"){ MODULE.exports = Gun } }catch(e){}
 		module.exports = Gun;
-		
+
 		(Gun.window||'').console = (Gun.window||'').console || {log: function(){}};
 		(C = console).only = function(i, s){ return (C.only.i && i === C.only.i && C.only.i++) && (C.log.apply(C, arguments) || s) };
 
@@ -2148,7 +2148,7 @@
 				var message, loop;
 				function each(peer){ mesh.say(message, peer) }
 				var say = mesh.say = function(msg, peer){
-					if(this.to){ this.to.next(msg) } // compatible with middleware adapters.
+					if(this && this.to){ this.to.next(msg) } // compatible with middleware adapters.
 					if(!msg){ return false }
 					var id, hash, tmp, raw;
 					var DBG = msg.DBG, S; if(!peer){ S = +new Date ; DBG && (DBG.y = S) }
@@ -2314,7 +2314,7 @@
 			});
 
 			root.on('bye', function(peer, tmp){
-				peer = opt.peers[peer.id || peer] || peer; 
+				peer = opt.peers[peer.id || peer] || peer;
 				this.to.next(peer);
 				peer.bye? peer.bye() : (tmp = peer.wire) && tmp.close && tmp.close();
 				Type.obj.del(opt.peers, peer.id);


### PR DESCRIPTION
In this PR:
- Added a `this` check in `mesh.say()` (gun.js) to fix an undefined error when using ES Modules

Please see this issue: https://github.com/amark/gun/issues/922