### PR TITLE
Fixed missing Gun.log.once function

### DIFF
--- a/lib/stats.js
+++ b/lib/stats.js
@@ -75,3 +75,4 @@ Gun.log = console.STAT = function(a,b,c,d){
 	if(!console.LOG || log.off){ return a }
 	return log.apply(Gun, arguments);
 }
+Gun.log.once = function(w,s,o){ return (o = Gun.log.once)[w] = o[w] || 0, o[w]++ || Gun.log(s) };


### PR DESCRIPTION
This fixes the error `Gun.log.once is not a function` when using gun like this:

```javascript
let items = gun.get('items');
items.once().map().once(cb);
```

The error would be thrown when calling `items.once()` in `gun.js:1801`, `Gun.chain.once`, `Gun.log.once("valonce", "...");`.

`Gun.log.once` was not set after setting Gun.log. To quickly fix the issue, I simply set the value in the same way as before (this is done in the same way in two different locations).
