### PR TITLE
Stop printing confusing error message (fixes #976)

### DIFF
--- a/examples/react-native/src/extensions/sea.js
+++ b/examples/react-native/src/extensions/sea.js
@@ -436,7 +436,6 @@
       if(cb){ try{ cb(r) }catch(e){console.log(e)} }
       return r;
     } catch(e) {
-      console.log(e); // mismatched owner FOR MARTTI
       SEA.err = e;
       if(cb){ cb() }
       return;

--- a/sea.js
+++ b/sea.js
@@ -453,7 +453,6 @@
       if(cb){ try{ cb(r) }catch(e){console.log(e)} }
       return r;
     } catch(e) {
-      console.log(e); // mismatched owner FOR MARTTI
       SEA.err = e;
       if(SEA.throw){ throw e }
       if(cb){ cb() }

--- a/sea/verify.js
+++ b/sea/verify.js
@@ -32,7 +32,6 @@
       if(cb){ try{ cb(r) }catch(e){console.log(e)} }
       return r;
     } catch(e) {
-      console.log(e); // mismatched owner FOR MARTTI
       SEA.err = e;
       if(SEA.throw){ throw e }
       if(cb){ cb() }


### PR DESCRIPTION
The error is already try/catch'd, and the correct way to deal with any error is by looking at the callback functions `ack.err`, so printing this message really only serves to confuse people, and should be removed.

See #976 