### PR TITLE
add: test node as client SEA auth

### DIFF
--- a/test/sea/nodeauth.js
+++ b/test/sea/nodeauth.js
@@ -1,0 +1,70 @@
+const Gun = require("../../index.js");
+const SEA = require("../../sea.js");
+const expect = require("../expect");
+const http = require("http");
+require("../../lib/promise");
+
+let gunClient, server;
+describe("SEA node client auth", () => {
+  it("should  start server", done => {
+    server = http.createServer().listen(8765, done);
+
+    let gunConfig = {
+      web: server
+    };
+
+    Gun(gunConfig);
+    gunClient = Gun({
+      file: "radataclient",
+      peers: ["http://localhost:8765/gun"]
+    });
+  });
+
+  it("should create user", done => {
+    gunClient.user().create("gun", "password", res => {
+      console.log({ res });
+      expect(res.err).to.equal(undefined);
+      done();
+    });
+  });
+
+  it("should not create new user when exists", done => {
+    gunClient2 = Gun({
+      file: "radataclient2",
+      peers: ["http://localhost:8765/gun"]
+    });
+    gunClient2.user().create("gun", "password", res => {
+      expect(res.err).to.equal("User already created!");
+      done();
+    });
+  });
+
+  it("should auth user", done => {
+    gunClient.user().auth("gun", "password", res => {
+      expect(res.err).to.equal(undefined);
+      done();
+    });
+  });
+
+  xit("should not stuck on null node", async () => {
+    const r1 = await gunClient
+      .user()
+      .once(console.log)
+      .get("test")
+      .promPut({ z: 1 });
+
+    const r2 = await gunClient
+      .user()
+      .get("test")
+      .promPut(null);
+    const res = await gunClient
+      .user()
+      .get("test")
+      .get("w");
+  });
+
+  after(() => {
+    server.close(() => {});
+    process.exit(-1);
+  });
+});


### PR DESCRIPTION
@amark 
added a mocha test file in test/sea that checks  that a node gun client can authenticate with a relay
this test fails on 520 (commit hash 022741dd9064a5cde8a77b45fd233b91df7669d2)
but passes on master.
I suggest to add it  to the unit tests