### PR TITLE
Remove node profiling from start script

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "ios": "browser.ios.js",
   "android": "browser.android.js",
   "scripts": {
-    "start": "node --prof examples/http.js",
+    "start": "node examples/http.js",
     "debug": "node --prof-process --preprocess -j isolate*.log > v8.json && rm isolate*.log && echo 'drag & drop ./v8.json into https://mapbox.github.io/flamebearer/'",
     "https": "HTTPS_KEY=test/https/server.key HTTPS_CERT=test/https/server.crt npm start",
     "prepublishOnly": "npm run unbuild",


### PR DESCRIPTION
Is the --prof option (for profiling node) intentional? I blindly copied the script on my test server setup and ended up with a 17gb v8 log :smile:

Anyone who runs `yarn start` or `npm start` is writing the profiling logs with this. I hope the one click Heroku deployment is using a different script