### PR TITLE
PANIC test semi-automation using Puppeteer

### DIFF
--- a/test/axe/holy-grail.js
+++ b/test/axe/holy-grail.js
@@ -80,7 +80,7 @@ describe("The Holy Grail AXE Test!", function(){
 	});
 
 	it(config.browsers +" browser(s) have joined!", function(){
-		console.log("PLEASE OPEN http://"+ config.IP +":"+ config.port +" IN "+ config.browsers +" BROWSER(S)!");
+		require('./util/open').web(config.browsers, "http://"+ config.IP +":"+ config.port);
 		return browsers.atLeast(config.browsers);
 	});
 

--- a/test/axe/holy-grail.js
+++ b/test/axe/holy-grail.js
@@ -413,11 +413,7 @@ describe("The Holy Grail AXE Test!", function(){
 		},1000);
 	});
 	after("Everything shut down.", function(){
-		browsers.run(function(){
-			//location.reload();
-			//setTimeout(function(){
-			//}, 15 * 1000);
-		});
+		require('./util/open').cleanup();
 		return servers.run(function(){
 			process.exit();
 		});

--- a/test/panic/1putackget.js
+++ b/test/panic/1putackget.js
@@ -82,7 +82,7 @@ describe("Put ACK", function(){
 	});
 
 	it(config.browsers +" browser(s) have joined!", function(){
-		console.log("PLEASE OPEN http://"+ config.IP +":"+ config.port +" IN "+ config.browsers +" BROWSER(S)!");
+		require('./util/open').web(config.browsers, "http://"+ config.IP +":"+ config.port);
 		return browsers.atLeast(config.browsers);
 	});
 

--- a/test/panic/1putackget.js
+++ b/test/panic/1putackget.js
@@ -188,11 +188,7 @@ describe("Put ACK", function(){
 	});
 
 	after("Everything shut down.", function(){
-		browsers.run(function(){
-			//location.reload();
-			//setTimeout(function(){
-			//}, 15 * 1000);
-		});
+		require('./util/open').cleanup();
 		return servers.run(function(){
 			process.exit();
 		});

--- a/test/panic/2getget.js
+++ b/test/panic/2getget.js
@@ -153,11 +153,7 @@ describe("Put ACK", function(){
 	});
 
 	after("Everything shut down.", function(){
-		browsers.run(function(){
-			//location.reload();
-			//setTimeout(function(){
-			//}, 15 * 1000);
-		});
+		require('./util/open').cleanup();
 		return servers.run(function(){
 			process.exit();
 		});

--- a/test/panic/2getget.js
+++ b/test/panic/2getget.js
@@ -83,7 +83,7 @@ describe("Put ACK", function(){
 	});
 
 	it(config.browsers +" browser(s) have joined!", function(){
-		console.log("PLEASE OPEN http://"+ config.IP +":"+ config.port +" IN "+ config.browsers +" BROWSER(S)!");
+		require('./util/open').web(config.browsers, "http://"+ config.IP +":"+ config.port);
 		return browsers.atLeast(config.browsers);
 	});
 

--- a/test/panic/3puts.js
+++ b/test/panic/3puts.js
@@ -82,7 +82,7 @@ describe("Put ACK", function(){
 	});
 
 	it(config.browsers +" browser(s) have joined!", function(){
-		console.log("PLEASE OPEN http://"+ config.IP +":"+ config.port +" IN "+ config.browsers +" BROWSER(S)!");
+		require('./util/open').web(config.browsers, "http://"+ config.IP +":"+ config.port);
 		return browsers.atLeast(config.browsers);
 	});
 

--- a/test/panic/3puts.js
+++ b/test/panic/3puts.js
@@ -125,11 +125,7 @@ describe("Put ACK", function(){
 	});
 
 	after("Everything shut down.", function(){
-		browsers.run(function(){
-			//location.reload();
-			//setTimeout(function(){
-			//}, 15 * 1000);
-		});
+		require('./util/open').cleanup();
 		return servers.run(function(){
 			process.exit();
 		});

--- a/test/panic/4dht.js
+++ b/test/panic/4dht.js
@@ -123,7 +123,7 @@ describe("Put ACK", function(){
 	});
 
 	it(config.browsers +" browser(s) have joined!", function(){
-		console.log("PLEASE OPEN http://"+ config.IP +":"+ config.port +" IN "+ config.browsers +" BROWSER(S)!");
+		require('./util/open').web(config.browsers, "http://"+ config.IP +":"+ config.port);
 		return browsers.atLeast(config.browsers);
 	});
 

--- a/test/panic/4dht.js
+++ b/test/panic/4dht.js
@@ -179,11 +179,7 @@ describe("Put ACK", function(){
 	});
 
 	after("Everything shut down.", function(){
-		browsers.run(function(){
-			//location.reload();
-			//setTimeout(function(){
-			//}, 15 * 1000);
-		});
+		require('./util/open').cleanup();
 		return servers.run(function(){
 			process.exit();
 		});

--- a/test/panic/b2s2s2b.js
+++ b/test/panic/b2s2s2b.js
@@ -166,11 +166,7 @@ describe("Load test "+ config.browsers +" browser(s) across "+ config.servers +"
 	});
 
 	after("Everything shut down.", function(){
-		browsers.run(function(){
-			//location.reload();
-			//setTimeout(function(){
-			//}, 15 * 1000);
-		});
+		require('./util/open').cleanup();
 		return servers.run(function(){
 			process.exit();
 		});

--- a/test/panic/b2s2s2b.js
+++ b/test/panic/b2s2s2b.js
@@ -73,7 +73,7 @@ describe("Load test "+ config.browsers +" browser(s) across "+ config.servers +"
 	});
 
 	it(config.browsers +" browser(s) have joined!", function(){
-		console.log("PLEASE OPEN http://"+ config.IP +":"+ config.port +" IN "+ config.browsers +" BROWSER(S)!");
+		require('./util/open').web(config.browsers, "http://"+ config.IP +":"+ config.port);
 		browsers.atLeast(1).then(function(){
 			browsers.run(function(test){
 				var env = test.props;

--- a/test/panic/bulkimport.js
+++ b/test/panic/bulkimport.js
@@ -82,7 +82,7 @@ describe("Put ACK", function(){
 	});
 
 	it(config.browsers +" browser(s) have joined!", function(){
-		console.log("PLEASE OPEN http://"+ config.IP +":"+ config.port +" IN "+ config.browsers +" BROWSER(S)!");
+		require('./util/open').web(config.browsers, "http://"+ config.IP +":"+ config.port);
 		return browsers.atLeast(config.browsers);
 	});
 

--- a/test/panic/bulkimport.js
+++ b/test/panic/bulkimport.js
@@ -125,11 +125,7 @@ describe("Put ACK", function(){
 	});
 
 	after("Everything shut down.", function(){
-		browsers.run(function(){
-			//location.reload();
-			//setTimeout(function(){
-			//}, 15 * 1000);
-		});
+		require('./util/open').cleanup();
 		return servers.run(function(){
 			process.exit();
 		});

--- a/test/panic/holy-grail.js
+++ b/test/panic/holy-grail.js
@@ -65,7 +65,7 @@ describe("The Holy Grail Test!", function(){
 	});
 
 	it(config.browsers +" browser(s) have joined!", function(){
-		console.log("PLEASE OPEN http://"+ config.IP +":"+ config.port +" IN "+ config.browsers +" BROWSER(S)!");
+		require('./util/open').web(config.browsers, "http://"+ config.IP +":"+ config.port);
 		return browsers.atLeast(config.browsers);
 	});
 

--- a/test/panic/holy-grail.js
+++ b/test/panic/holy-grail.js
@@ -267,11 +267,7 @@ describe("The Holy Grail Test!", function(){
 	});
 
 	after("Everything shut down.", function(){
-		browsers.run(function(){
-			//location.reload();
-			//setTimeout(function(){
-			//}, 15 * 1000);
-		});
+		require('./util/open').cleanup();
 		return servers.run(function(){
 			process.exit();
 		});

--- a/test/panic/livestream.js
+++ b/test/panic/livestream.js
@@ -180,11 +180,7 @@ describe("Broadcast Video", function(){
 	});
 
 	after("Everything shut down.", function(){
-		browsers.run(function(){
-			//location.reload();
-			//setTimeout(function(){
-			//}, 15 * 1000);
-		});
+		require('./util/open').cleanup();
 		return servers.run(function(){
 			process.exit();
 		});

--- a/test/panic/livestream.js
+++ b/test/panic/livestream.js
@@ -82,7 +82,7 @@ describe("Broadcast Video", function(){
 	});
 
 	it(config.browsers +" browser(s) have joined!", function(){
-		console.log("PLEASE OPEN http://"+ config.IP +":"+ config.port +" IN "+ config.browsers +" BROWSER(S)!");
+		require('./util/open').web(config.browsers, "http://"+ config.IP +":"+ config.port);
 		return browsers.atLeast(config.browsers);
 	});
 

--- a/test/panic/load.js
+++ b/test/panic/load.js
@@ -249,7 +249,7 @@ describe("Load test "+ config.browsers +" browser(s) across "+ config.servers +"
 
 	after("Everything shut down.", function(){
 		// which is to shut down all the browsers.
-		browsers.run(function(){
+		require('./util/open').cleanup() || browsers.run(function(){
 			setTimeout(function(){
 				location.reload();
 			}, 15 * 1000);

--- a/test/panic/load.js
+++ b/test/panic/load.js
@@ -105,8 +105,8 @@ describe("Load test "+ config.browsers +" browser(s) across "+ config.servers +"
 
 	it(config.browsers +" browser(s) have joined!", function(){
 		// Okay! Cool. Now we can move on to the next step...
-		console.log("PLEASE OPEN http://"+ config.IP +":"+ config.port +" IN "+ config.browsers +" BROWSER(S)!");
-		// Which is to manually open up a bunch of browser tabs
+		require('./util/open').web(config.browsers, "http://"+ config.IP +":"+ config.port);
+		// Which is to automatically or manually open up a bunch of browser tabs
 		// and connect to the PANIC server in the same way
 		// the NodeJS servers did.
 

--- a/test/panic/no-override.js
+++ b/test/panic/no-override.js
@@ -118,11 +118,7 @@ describe("No Empty Object on .Once", function(){
 	});
 
 	after("Everything shut down.", function(){
-		browsers.run(function(){
-			//location.reload();
-			//setTimeout(function(){
-			//}, 15 * 1000);
-		});
+		require('./util/open').cleanup();
 		return servers.run(function(){
 			process.exit();
 		});

--- a/test/panic/no-override.js
+++ b/test/panic/no-override.js
@@ -75,7 +75,7 @@ describe("No Empty Object on .Once", function(){
 	});
 
 	it(config.browsers +" browser(s) have joined!", function(){
-		console.log("PLEASE OPEN http://"+ config.IP +":"+ config.port +" IN "+ config.browsers +" BROWSER(S)!");
+		require('./util/open').web(config.browsers, "http://"+ config.IP +":"+ config.port);
 		return browsers.atLeast(config.browsers);
 	});
 

--- a/test/panic/on-recovery.js
+++ b/test/panic/on-recovery.js
@@ -217,7 +217,7 @@ describe("gun.on should receive updates after crashed relay peer comes back onli
 	});
 
 	after("Everything shut down.", function(){
-		return bob.run(function(){
+		return require('./util/open').cleanup() || bob.run(function(){
 			process.exit();
 		});
 	});

--- a/test/panic/on-recovery.js
+++ b/test/panic/on-recovery.js
@@ -72,7 +72,7 @@ describe("gun.on should receive updates after crashed relay peer comes back onli
 	});
 
 	it(config.browsers +" browser(s) have joined!", function(){
-		console.log("PLEASE OPEN http://"+ config.IP +":"+ config.port +" IN "+ config.browsers +" BROWSER(S)!");
+		require('./util/open').web(config.browsers, "http://"+ config.IP +":"+ config.port);
 		return browsers.atLeast(config.browsers);
 	});
 

--- a/test/panic/radisk.js
+++ b/test/panic/radisk.js
@@ -275,11 +275,7 @@ describe("Make sure the Radix Storage Engine (RAD) works.", function(){
 	});
 
 	after("Everything shut down.", function(){
-		browsers.run(function(){
-			//location.reload();
-			//setTimeout(function(){
-			//}, 15 * 1000);
-		});
+		require('./util/open').cleanup();
 		return servers.run(function(){
 			process.exit();
 		});

--- a/test/panic/radisk.js
+++ b/test/panic/radisk.js
@@ -74,7 +74,7 @@ describe("Make sure the Radix Storage Engine (RAD) works.", function(){
 	});
 
 	it(config.browsers +" browser(s) have joined!", function(){
-		console.log("PLEASE OPEN http://"+ config.IP +":"+ config.port +" IN "+ config.browsers +" BROWSER(S)!");
+		require('./util/open').web(config.browsers, "http://"+ config.IP +":"+ config.port);
 		return browsers.atLeast(config.browsers);
 	});
 

--- a/test/panic/scale.js
+++ b/test/panic/scale.js
@@ -223,11 +223,7 @@ describe("Stress test GUN with SEA users causing PANIC!", function(){
 	});
 
 	after("Everything shut down.", function(){
-		browsers.run(function(){
-			//location.reload();
-			//setTimeout(function(){
-			//}, 15 * 1000);
-		});
+		require('./util/open').cleanup();
 		return servers.run(function(){
 			process.exit();
 		});

--- a/test/panic/set.js
+++ b/test/panic/set.js
@@ -188,11 +188,7 @@ describe("Make sure SEA syncs correctly", function(){
 	});
 
 	after("Everything shut down.", function(){
-		browsers.run(function(){
-			//location.reload();
-			//setTimeout(function(){
-			//}, 15 * 1000);
-		});
+		require('./util/open').cleanup();
 		return servers.run(function(){
 			process.exit();
 		});

--- a/test/panic/set.js
+++ b/test/panic/set.js
@@ -65,7 +65,7 @@ describe("Make sure SEA syncs correctly", function(){
 	});
 
 	it(config.browsers +" browser(s) have joined!", function(){
-		console.log("PLEASE OPEN http://"+ config.IP +":"+ config.port +" IN "+ config.browsers +" BROWSER(S)!");
+		require('./util/open').web(config.browsers, "http://"+ config.IP +":"+ config.port);
 		return browsers.atLeast(config.browsers);
 	});
 

--- a/test/panic/speak.js
+++ b/test/panic/speak.js
@@ -310,11 +310,7 @@ describe("Stress test GUN with SEA users causing PANIC!", function(){
 	});
 
 	after("Everything shut down.", function(){
-		browsers.run(function(){
-			//location.reload();
-			//setTimeout(function(){
-			//}, 15 * 1000);
-		});
+		require('./util/open').cleanup();
 		return servers.run(function(){
 			process.exit();
 		});

--- a/test/panic/thread.js
+++ b/test/panic/thread.js
@@ -218,11 +218,7 @@ describe("Private Message Threading", function(){
 	});
 
 	after("Everything shut down.", function(){
-		browsers.run(function(){
-			//location.reload();
-			//setTimeout(function(){
-			//}, 15 * 1000);
-		});
+		require('./util/open').cleanup();
 		return servers.run(function(){
 			process.exit();
 		});

--- a/test/panic/thread.js
+++ b/test/panic/thread.js
@@ -64,7 +64,7 @@ describe("Private Message Threading", function(){
 	});
 
 	it(config.browsers +" browser(s) have joined!", function(){
-		console.log("PLEASE OPEN http://"+ config.IP +":"+ config.port +" IN "+ config.browsers +" BROWSER(S)!");
+		require('./util/open').web(config.browsers, "http://"+ config.IP +":"+ config.port);
 		return browsers.atLeast(config.browsers);
 	});
 

--- a/test/panic/users.js
+++ b/test/panic/users.js
@@ -253,11 +253,7 @@ describe("End-to-End Encryption on User Accounts", function(){
 	});
 
 	after("Everything shut down.", function(){
-		browsers.run(function(){
-			//location.reload();
-			//setTimeout(function(){
-			//}, 15 * 1000);
-		});
+		require('./util/open').cleanup();
 		return servers.run(function(){
 			process.exit();
 		});

--- a/test/panic/users.js
+++ b/test/panic/users.js
@@ -65,7 +65,7 @@ describe("End-to-End Encryption on User Accounts", function(){
 	});
 
 	it(config.browsers +" browser(s) have joined!", function(){
-		console.log("PLEASE OPEN http://"+ config.IP +":"+ config.port +" IN "+ config.browsers +" BROWSER(S)!");
+		require('./util/open').web(config.browsers, "http://"+ config.IP +":"+ config.port);
 		return browsers.atLeast(config.browsers);
 	});
 

--- a/test/panic/util/open.js
+++ b/test/panic/util/open.js
@@ -1,0 +1,34 @@
+module.exports = {
+    web: (count, url, options) => {
+        if (typeof count === 'string') {
+            options = url;
+            url = count;
+            count = 1;
+        }
+        if (!url || typeof url !== 'string') {
+            throw new Error('Invalid URL');
+        }
+        try {
+			require('puppeteer').launch(options).then(browser => {
+				Array(count).fill(0).forEach((x, i) => {
+					console.log('Opening browser page ' + i + ' with puppeteer...');
+					browser.newPage().then(page => {
+						page.on('console', msg => {
+							if (msg.text() === 'JSHandle@object') {
+								// FIXME: Avoid text comparison
+								return;
+							}
+							console.log(`${i} [${msg.type()}]: ${msg.text()}`);
+						});
+						return page.goto(url);
+					}).then(() => {
+						console.log('Browser page ' + i + ' open');
+					});
+				});
+			});
+		} catch (err) {
+			console.log("PLEASE OPEN "+ url +" IN "+ count +" BROWSER(S)!");
+			console.warn('Consider installing puppeteer to automate browser management (npm i -g puppeteer && npm link puppeteer)');
+		}
+    }
+}

--- a/test/panic/util/open.js
+++ b/test/panic/util/open.js
@@ -1,3 +1,5 @@
+let _browsers = [];
+
 module.exports = {
     web: (count, url, options) => {
         if (typeof count === 'string') {
@@ -10,6 +12,7 @@ module.exports = {
         }
         try {
 			require('puppeteer').launch(options).then(browser => {
+				_browsers.push(browser);
 				Array(count).fill(0).forEach((x, i) => {
 					console.log('Opening browser page ' + i + ' with puppeteer...');
 					browser.newPage().then(page => {
@@ -30,5 +33,13 @@ module.exports = {
 			console.log("PLEASE OPEN "+ url +" IN "+ count +" BROWSER(S)!");
 			console.warn('Consider installing puppeteer to automate browser management (npm i -g puppeteer && npm link puppeteer)');
 		}
-    }
+	},
+	cleanup: () => {
+		if (_browsers.length === 0) {
+			return undefined;
+		}
+		console.log('Closing all puppeteer browsers...');
+		return Promise.all(_browsers.map(b => b.close()))
+			.then(() => console.log('Closed all puppeteer browsers'));
+	}
 }

--- a/test/panic/who.js
+++ b/test/panic/who.js
@@ -233,11 +233,7 @@ describe("Make sure SEA syncs correctly", function(){
 	});
 
 	after("Everything shut down.", function(){
-		browsers.run(function(){
-			//location.reload();
-			//setTimeout(function(){
-			//}, 15 * 1000);
-		});
+		require('./util/open').cleanup();
 		return servers.run(function(){
 			process.exit();
 		});

--- a/test/panic/who.js
+++ b/test/panic/who.js
@@ -65,7 +65,7 @@ describe("Make sure SEA syncs correctly", function(){
 	});
 
 	it(config.browsers +" browser(s) have joined!", function(){
-		console.log("PLEASE OPEN http://"+ config.IP +":"+ config.port +" IN "+ config.browsers +" BROWSER(S)!");
+		require('./util/open').web(config.browsers, "http://"+ config.IP +":"+ config.port);
 		return browsers.atLeast(config.browsers);
 	});
 


### PR DESCRIPTION
Using a utility method, it's possible to opt in to using Puppeteer to automatically launch browsers. Just run inside gun root:

```
npm i -g puppeteer && npm link puppeteer
```

and when running a PANIC test, Puppeteer will take care of opening browsers.

Completely optional and the old manual approach still works.

Revert with `npm unlink puppeteer`.