### PR TITLE
[Manhattan] Allow passing test cli args.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "debug": "node --prof-process --preprocess -j isolate*.log > v8data.json && rm isolate*.log && echo 'drag & drop ./v8data.json into https://mapbox.github.io/flamebearer/'",
     "https": "HTTPS_KEY=test/https/server.key HTTPS_CERT=test/https/server.crt npm start",
     "prepublishOnly": "npm run unbuild",
-    "test": "mocha && echo 'Did you run PANIC holy-grail, 1~X, on-recover, etc.?'",
+    "test": "echo 'Did you run PANIC holy-grail, 1~X, on-recover, etc.?' && mocha",
     "testsea": "mocha test/sea/sea.js",
     "testaxe": "mocha test/axe/holy-grail.js",
     "e2e": "mocha e2e/distributed.js",


### PR DESCRIPTION
Before, no CLI args would be passed when running `npm test`. Keeping the `mocha` at the end of the test script allows passing CLI args to Mocha.