### PR TITLE
Fixed issue 935. Detects zero length key

### DIFF
--- a/gun.js
+++ b/gun.js
@@ -1349,6 +1349,10 @@
 		Gun.chain.get = function(key, cb, as){
 			var gun, tmp;
 			if(typeof key === 'string'){
+			        if(key.length == 0) {
+			              (as = this.chain())._.err = {err: Gun.log('Invalid zero length string key!', key)};
+			              return null
+			        }
 				var back = this, cat = back._;
 				var next = cat.next || empty;
 				if(!(gun = next[key])){


### PR DESCRIPTION
Closes #935 

Returns null after an attempt to .get() a zero-length key.

```
gun.get('a').get('').put({hey: 1})
```

Now yields:

```
Invalid zero length string key!
```

And `Uncaught TypeError: Cannot read property 'put' of null...` for the chained put.
