### PR TITLE
(WIP) Bug rad reverse sorting

### DIFF
--- a/lib/store.js
+++ b/lib/store.js
@@ -56,7 +56,7 @@ Gun.on('create', function(root){
         if((tmp = get['%']) || o.limit){
             o.limit = (tmp <= (o.pack || (1000 * 100)))? tmp : 1;
         }
-        if(has['-'] || (soul||{})['-']){ o.reverse = true }
+        if(has['-'] || (soul||{})['-'] || get['-']){ o.reverse = true; }
         if((tmp = (root.next||'')[soul]) && tmp.put){
             if(o.atom){
                 tmp = (tmp.next||'')[o.atom] ;
@@ -89,7 +89,7 @@ Gun.on('create', function(root){
                     if(o.atom){
                         data = u;
                     } else {
-                        Radix.map(data, each); // IS A RADIX TREE, NOT FUNCTION!
+                        Radix.map(data, each, o); // IS A RADIX TREE, NOT FUNCTION!
                     }
                 }
                 if(!graph && data){ each(data, '') }

--- a/test/rad/rad.js
+++ b/test/rad/rad.js
@@ -399,18 +399,15 @@ var names = ["Adalard","Adora","Aia","Albertina","Alfie","Allyn","Amabil","Ammam
         });
     });
 
-    it.skip('read contacts in descending order', function(done){ // TODO!!!
-        var all = {}, cursor = 'm', to;
-        names.forEach(function(v){
-            all[v] = true;
-        });
-        gun.get('names').get({'.': {'-': true}, '%': 1000 * 100}).once().map().once(function(data, key){
-            expect(data.name).to.be.ok();
-            expect(data.age).to.be.ok();
-            delete all[key];
+    it('read contacts in descending order', function(done){
+        var to; 
+        const filtered = [...names].filter(v => v.startsWith('M'));
+
+        gun.get('names').get({'.': { '*': 'm' }, '%': 1000 * 100, '-': 1}).map().once(function(data){
+            expect(filtered.pop()).to.be(data.name);
             clearTimeout(to);
             to = setTimeout(function(){
-                expect(Gun.obj.empty(all)).to.be.ok();
+                expect(filtered.length).to.be(0);
                 done();
             },100);
         });

--- a/test/rad/rad.js
+++ b/test/rad/rad.js
@@ -401,7 +401,7 @@ var names = ["Adalard","Adora","Aia","Albertina","Alfie","Allyn","Amabil","Ammam
 
     it('read contacts in descending order', function(done){
         var to; 
-        const filtered = [...names].filter(v => v.startsWith('M'));
+        const filtered = names.filter(v => v.startsWith('M'));
 
         gun.get('names').get({'.': { '*': 'm' }, '%': 1000 * 100, '-': 1}).map().once(function(data){
             expect(filtered.pop()).to.be(data.name);


### PR DESCRIPTION
This PR aims to fix the issues with `reverse` when using RAD's lexical querying. I've tested the fix in the browser and it works, but, for some reason, the test is not passing (reverse is not working when running mocha)