### PR TITLE
Improving websocket retry logic to support no retries

### DIFF
--- a/src/adapters/websocket.js
+++ b/src/adapters/websocket.js
@@ -47,7 +47,15 @@ Gun.on('opt', function(root){
 	var wait = 2 * 1000;
 	function reconnect(peer){
 		clearTimeout(peer.defer);
-		if(doc && peer.retry <= 0){ return } peer.retry = (peer.retry || opt.retry || 60) - 1;
+		let retry = 60;
+		if (peer.retry !== undefined) {
+			retry = peer.retry;
+		} else if (opt.retry !== undefined) {
+			retry = opt.retry;
+		}
+		peer.retry = retry;
+		if (doc && peer.retry <= 0) { return }
+		peer.retry -= 1;
 		peer.defer = setTimeout(function to(){
 			if(doc && doc.hidden){ return setTimeout(to,wait) }
 			open(peer);


### PR DESCRIPTION
I tried to kill my connection to a peer from the frontend manually, but the websocket adapter had some messy logic around retries passed via options.

This PR changes the logic so that it's able to determine if i've manually set retries to zero earlier. 

I also improved the logic to identify `opt.retry = 0` which before was causing unexpected logic.