### PR TITLE
fix: salt should not be random #1052

### DIFF
--- a/sea.js
+++ b/sea.js
@@ -278,7 +278,7 @@
         if(cb){ try{ cb(rsha) }catch(e){console.log(e)} }
         return rsha;
       }
-      salt = salt || shim.random(9);
+      salt = salt || '';
       var key = await (shim.ossl || shim.subtle).importKey('raw', new shim.TextEncoder().encode(data), {name: opt.name || 'PBKDF2'}, false, ['deriveBits']);
       var work = await (shim.ossl || shim.subtle).deriveBits({
         name: opt.name || 'PBKDF2',


### PR DESCRIPTION
see #1052 
this causes hash tables to fail, because a different hash will be generated for content every time.
in case incomming salt is null, it will be set to always be the empty string