### PR TITLE
Improvements to automatic redirect on loading SEA module

### DIFF
--- a/sea.js
+++ b/sea.js
@@ -35,6 +35,7 @@
     try{ if(SEA.window){
       if(location.protocol.indexOf('s') < 0
       && location.host.indexOf('localhost') < 0
+      && ! /^127\.\d+\.\d+\.\d+$/.test(location.hostname)
       && location.protocol.indexOf('file:') < 0){
         console.warn('WebCrypto used by GUN SEA implementation does not work without HTTPS. Will automatically redirect.')
         location.protocol = 'https:'; // WebCrypto does NOT work without HTTPS!

--- a/sea.js
+++ b/sea.js
@@ -36,6 +36,7 @@
       if(location.protocol.indexOf('s') < 0
       && location.host.indexOf('localhost') < 0
       && location.protocol.indexOf('file:') < 0){
+        console.warn('WebCrypto used by GUN SEA implementation does not work without HTTPS. Will automatically redirect.')
         location.protocol = 'https:'; // WebCrypto does NOT work without HTTPS!
       }
     } }catch(e){}


### PR DESCRIPTION
This PR addresses and closes #1041.

Summary of changes:

- Prints a warning message in console when users of SEA module is being automatically redirected to HTTPS;
- Checks if current location falls in the range of loopback IP (`127.0.0.0/8`) and stays HTTP (since it is usually used by developers for testing, same as `localhost`).

Please let me know if there are anything that is unappropriate and needs improvement.

cc @amark

PS: Personally I think redirecting to HTTPS is not supposed to be performed by GUN as a library (as pointed out in #992), and current automatic redirect should be a workaround only; but other radical changes may lead to many more broken sites so I did not make any further changes.