### PR TITLE
Fix: certificants' pub strings now pass to cert

### DIFF
--- a/sea.js
+++ b/sea.js
@@ -669,7 +669,7 @@
       certificants = (() => {
         var data = []
         if (certificants) {
-          if ((typeof certificants === 'string' || Array.isArray(certificants)) && certificants.indexOf('*')) return '*'
+          if ((typeof certificants === 'string' || Array.isArray(certificants)) && certificants.indexOf('*') !== -1) return '*'
           
           if (typeof certificants === 'string') {
             return certificants


### PR DESCRIPTION
`certificants.indexOf('*') !== -1` appears to be correct way of using this function to check if '*' is there. 

`certificants.includes` may be another option, but it may be too modern for compatibility concern