### PR TITLE
Add git to Dockerfile apks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ ADD . .
 ENV NPM_CONFIG_LOGLEVEL warn
 RUN apk update && apk upgrade \
   && apk add --no-cache ca-certificates nodejs-npm \
-  && apk add --no-cache --virtual .build-dependencies python2 make g++ \
+  && apk add --no-cache --virtual .build-dependencies python2 make g++ git \
   && npm install --production=false \
   && apk del .build-dependencies && rm -rf /var/cache/* /tmp/npm*
 EXPOSE 8080


### PR DESCRIPTION
Git needs to be added to the docker image or the build fails at the npm install stage.

_Looks at iris_

```
npm ERR! path git
npm ERR! errno -2
npm ERR! enoent undefined ls-remote -h -t ssh://git@github.com/irislib/iris-messenger.git

```