### PR TITLE
fix(types): .set() should allow IGunChainReference

### DIFF
--- a/types/chain.d.ts
+++ b/types/chain.d.ts
@@ -83,7 +83,9 @@ export interface IGunChainReference<DataType = Record<string, any>, ReferenceKey
      *
      * **This means only objects, for now, are supported.**
      */
-    set(data: MaybeGunChainReference< AlwaysDisallowedType<DataType extends Array<infer U> ? U extends Record<string|number, any> ? ArrayOf<DataType> : never : never>>, callback?: AckCallback): IGunChainReference<ArrayOf<DataType>>;
+    set(data: MaybeGunChainReference<AlwaysDisallowedType<DataType extends Array<infer U> ? U extends Record<string|number, any> ? ArrayOf<DataType> : never : never>>, 
+		callback?: AckCallback
+	): IGunChainReference<ArrayOf<DataType>>;
     /**
      * Map iterates over each property and item on a node, passing it down the chain,
      * behaving like a forEach on your data.

--- a/types/chain.d.ts
+++ b/types/chain.d.ts
@@ -91,8 +91,9 @@ export interface IGunChainReference<DataType = Record<string, any>, ReferenceKey
      * behaving like a forEach on your data.
      * It also subscribes to every item as well and listens for newly inserted items.
      */
-    map(callback?: (value: ArrayOf<DataType>, key: DataType) => ArrayOf<DataType> | undefined): IGunChainReference<ArrayOf<DataType>, ReferenceKey>;
-    /**
+	map(callback?: (value: ArrayOf<DataType>, key: DataType) => ArrayOf<DataType> | undefined
+	): IGunChainReference<DataType extends Array<unknown> ? ArrayOf<DataType> : DataType extends Record<any,infer V> ? V : never, ReferenceKey>;
+	 /**
      * Undocumented, but extremely useful and mentioned in the document
      *
      * Remove **all** listener on this node.

--- a/types/chain.d.ts
+++ b/types/chain.d.ts
@@ -1,7 +1,9 @@
-import { AlwaysDisallowedType, DisallowPrimitives, DisallowArray, AckCallback, ArrayOf, ArrayAsRecord, Saveable, IGunCryptoKeyPair } from './types';
+import { AlwaysDisallowedType, DisallowPrimitives, DisallowArray, AckCallback, ArrayOf, ArrayAsRecord, Saveable, IGunCryptoKeyPair, MaybeGunChainReference } from './types';
 import { IGunConstructorOptions } from './options';
 
 declare type ITSResolvable<R> = R | PromiseLike<R>;
+/** for cases where a chain reference is acceptable, such as an argument to `.set()` */
+
 export interface IGunChainReference<DataType = Record<string, any>, ReferenceKey = any, IsTop extends 'pre_root' | 'root' | false = false> {
     /**
      * Save data into gun, syncing it with your connected peers.
@@ -81,10 +83,7 @@ export interface IGunChainReference<DataType = Record<string, any>, ReferenceKey
      *
      * **This means only objects, for now, are supported.**
      */
-    set(data: AlwaysDisallowedType<DataType extends Array<infer U> ? U extends {
-        [key: string]: any;
-        [key: number]: any;
-    } ? ArrayOf<DataType> : never : never>, callback?: AckCallback): IGunChainReference<ArrayOf<DataType>>;
+    set(data: MaybeGunChainReference< AlwaysDisallowedType<DataType extends Array<infer U> ? U extends Record<string|number, any> ? ArrayOf<DataType> : never : never>>, callback?: AckCallback): IGunChainReference<ArrayOf<DataType>>;
     /**
      * Map iterates over each property and item on a node, passing it down the chain,
      * behaving like a forEach on your data.

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -35,3 +35,4 @@ export declare type IGunRecordNode<DataType> = {
     [K in keyof DataType]: IGunRecordNodeRawBase;
 } & IGunRecordNodeRaw<DataType>;
 export declare type IGunRecordData<DataType> = DataType & IGunRecordNodeRaw<DataType>;
+export declare type MaybeGunChainReference<DataType = Record<string, any>, ReferenceKey = any> = DataType | IGunChainReference<DataType, ReferenceKey, false>


### PR DESCRIPTION
First off, thanks for the great work on Gun! I've been a long time lurker/tinkerer, but I'm finally getting around to a real project with it.

This PR fixes a small typescript bug that I ran into (I think!) -- per the example in the docs for `.set()`, it seems that one should be able to pass either an object with the acceptable key/value types (as is currently already checked for) or an `IGunChainReference<T>` where T meets the same key/value constraints.

```ts
interface Person {
    name: string
    friends: Person[]
}

var gun = Gun<Record<string, Person>>();
var bob = gun.get('bob').put({name: "Bob"});
var dave = gun.get('dave').put({name: "Dave"});

dave.get('friends').set(bob); // <--- These both throw typescript errors for me, because `bob` and `dave`
bob.get('friends').set(dave); // <--- are both IGunChainableReference<Person>, not Person
```
I've added a utility type of `MaybeGunChainReference` which is simply a union like `T | IGunChainReference<T>` and wrapped the entire `data` argument type of `set()` with this utility type

I also simplified the type definition of `data` using the `Record` in place of the index signature type.

## Updates

I also ran into a problem with the definition of `.map()`, if I call map on a non-array property, Gun expects to simply iterate over the keys, however the return type of `.map()` forces the chain to `never` if the mapped property is not an array type, despite it working fine at runtime.

I've added some additional type logic for cases where the mapped property is not an array but is an object. This can likely be improved in the future to filter out any non-conforming keys, etc.