### PR TITLE
radisk: md5 hash file names > 255 characters

### DIFF
--- a/lib/radisk.js
+++ b/lib/radisk.js
@@ -17,7 +17,23 @@
 		opt.jsonify = true;
 
 
-		function ename(t){ return encodeURIComponent(t).replace(/\*/g, '%2A') }
+		var crypto, enamemap;
+		try { // try requiring crypto, should only succeed on node
+			crypto = require("crypto");
+			enamemap = new Map(); // keep an in-memory map of known hashes
+			opt.maxKeyLength = opt.maxKeyLength < 0 ? opt.maxKeyLength : opt.maxKeyLength || 255; // feature can be disabled by setting opt.maxKeyLength <= 32
+		} catch (e) {	delete opt.maxKeyLength	}
+		function ename(t) {
+			var s = encodeURIComponent(t).replace(/\*/g, '%2A');
+			if (crypto && opt.maxKeyLength > 32 && s.length > opt.maxKeyLength) {
+				if (!enamemap.has(s)) {
+					enamemap.set(s, crypto.createHash('md5').update(s).digest('hex'));
+					// TODO evict old map entries, or add this entry to %1C
+				}
+				return enamemap.get(s);
+			}
+			return s;
+		}
 		function atomic(v){ return u !== v && (!v || 'object' != typeof v) }
 		var timediate = (typeof setImmediate === "undefined")? setTimeout : setImmediate;
 		var puff = setTimeout.puff || timediate;


### PR DESCRIPTION
This solves the issue of radisk attempting to write to filenames with lengths exceeding the 255 character limit of most filesystems (issue here: https://github.com/amark/gun/issues/1070).

This is a different approach than that used in https://github.com/amark/gun/pull/1005 and touches only the `ename` function. If the sanitized file name would exceed the limit set by opt.maxKeyLength (and maxKeyLength is greater than 32 bytes required for the hash), I return an MD5 hash instead. The modification should also leave the browser radisk functionality untouched, to avoid compatibility issues. If this is a bad approach, or I haven't fully understood how ename works, my apologies.

I do not know whether it is necessary to add the hashes to the %1C file, since the path hashes are deterministic. If this is necessary, I need guidance on how to interact with that file. I have created a Map of paths to their respective hashes for performance's sake, though it may take up too much memory over a long enough span of time.