### PR TITLE
Panic browser imports

### DIFF
--- a/test/panic/util/load-browser-scripts.js
+++ b/test/panic/util/load-browser-scripts.js
@@ -1,0 +1,41 @@
+module.exports = {
+  /**
+   * Loads scripts in PANIC clients
+   * @param browsers a Panic.ClientList of browsers
+   * @param paths an array of paths to desired .js files
+   * @returns Promise which will resolve when all browsers have loaded all dependencies
+   */
+  loadBrowserScripts: function (browsers, paths) {
+    var promises = [];
+    browsers.each(function (client, id) {
+      promises.push(client.run(function (test) {
+        test.async();
+        var env = test.props;
+        var imports = env.paths || [];
+        /** Loads a single script in the browser */
+        function load(src, cb) {
+          var script = document.createElement('script');
+          script.onload = cb; script.src = src;
+          document.head.appendChild(script);
+        }
+        /** Loads scripts in order, waiting on each to load before proceeding */
+        function loadAll(src, cb) {
+          if (src.length === 0) {
+            cb();
+            return;
+          }
+          var cur = src.shift();
+          // console.log('loading library:', cur);
+          load(cur, function () {
+            loadAll(src, cb);
+          });
+        }
+
+        loadAll(imports, function () {
+          test.done();
+        });
+      }, {paths: paths}));
+    });
+    return Promise.all(promises);
+  }
+};


### PR DESCRIPTION
# Add utility for loading scripts on panic clients

This utility file provides a function which takes a PANIC Client List, and an array of paths to .js files, and loads those .js files on each browser. This is useful for tests requiring multiple scripts to be loaded. It returns a promise which resolves when all browsers have loaded all scripts, so it can be used within a typical Mocha test step.

## How to use this utility

First, import the `loadBrowserScripts` function from its module:

```javascript
var {loadBrowserScripts} = require('./util/load-browser-scripts');
```

Before your "Browsers initialized Gun!" test step, include the following test step (replace the example array of scripts with actual scripts your test requires). Note: the script paths provided to loadBrowserScripts must be available in your test's route configuration

```javascript
it('Browsers loaded scripts!', function () {
  return loadBrowserScripts(browsers, [
    'your.js',
    'array.js',
    'of.js',
    'scripts.js',
  ]);
});
```

That's it! The provided array of script paths will be loaded in the order you provide, on every browser.
