### PR TITLE
Change URL for devdependency iris-messenger so that build passes.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/ws": "^7.2.1",
         "aws-sdk": "^2.528.0",
         "ip": "^1.1.5",
-        "iris-messenger": "github:irislib/iris-messenger",
+        "iris-messenger": "git://github.com/irislib/iris-messenger.git",
         "mocha": "^6.2.0",
         "panic-manager": "^1.2.0",
         "panic-server": "^1.1.1",
@@ -4321,7 +4321,7 @@
       "version": "git+ssh://git@github.com/irislib/iris-messenger.git#dc24693f99ccaa08fddb7aa05d4d86878d8f0907",
       "integrity": "sha512-zFrtkvKqjpsC75kDM++dcQu1o4kJDDCRh78baBF5CeOd3NxR/BqV5AqMVcXe3G6CWQvZyUN4VxyskRENwrt7YQ==",
       "dev": true,
-      "from": "iris-messenger@github:irislib/iris-messenger"
+      "from": "iris-messenger@git://github.com/irislib/iris-messenger.git"
     },
     "irregular-plurals": {
       "version": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "@types/ws": "^7.2.1",
     "aws-sdk": "^2.528.0",
     "ip": "^1.1.5",
-    "iris-messenger": "github:irislib/iris-messenger",
+    "iris-messenger": "git://github.com/irislib/iris-messenger.git",
     "mocha": "^6.2.0",
     "panic-manager": "^1.2.0",
     "panic-server": "^1.1.1",


### PR DESCRIPTION
Previously the url github:irislib/iris-messenger.git was causing an SSH fetch, which the CI server cannot execute.
This change updates the URL to use the git protocol git:// which the CI server can execute.