### PR TITLE
Halt `rap` function on undefined key

### DIFF
--- a/lib/radix.js
+++ b/lib/radix.js
@@ -74,7 +74,7 @@
 		var start = opt.start, end = opt.end, END = '\uffff';
 		var i = 0, l = keys.length;
 		for(;i < l; i++){ var key = keys[i], tree = t[key], tmp, p, pt;
-			if(!tree || '' === key || _ === key){ continue }
+			if(!tree || '' === key || _ === key || 'undefined' === key){ continue }
 			p = pre.slice(0); p.push(key);
 			pt = p.join('');
 			if(u !== start && pt < (start||'').slice(0,pt.length)){ continue }


### PR DESCRIPTION
This PR fixes an infinite loop error that sometimes occurs when the specified key doesn't exist, I've attached a Node debugger to our app while it was running and logged the `pre` argument's value and it seems like almost all instances where the function goes into an infinite loop occurs when an `undefined` value gets pushed into the `pre` array. Once that occurs, the function keeps on calling itself while pushing `0` value entries into the array indefinitely until the process runs out of memory and this gets logged into the console: `RangeError: Maximum call stack size exceeded`

I've implemented a fix now so once the for loop inside the `rap` function encounters an `undefined` key, it should skip it and move on to the next entry in the loop.

Let me know if you need me to implement any fixes to this PR and I will implement it asap! 😄 