### PR TITLE
change stats.radata file

### DIFF
--- a/lib/stats.js
+++ b/lib/stats.js
@@ -6,12 +6,16 @@ Gun.on('opt', function(root){
 	if(typeof process === 'undefined'){ return }
 	if(typeof require === 'undefined'){ return }
 	if(false === root.opt.stats){ return }
-	var file = root.opt.file || 'radata';
+	// var file = root.opt.file || 'radata';
+	var file = 'radata';
 	var noop = function(){};
 	var os = require('os') || {};
 	var fs = require('fs') || {};
 	fs.existsSync = fs.existsSync || require('path').existsSync;
 	if(!fs.existsSync){ return }
+	if(!fs.existsSync(__dirname+'/../stats.'+file)){
+		fs.writeFileSync(__dirname+'/../stats.'+file, '')
+	}
 	if(!process){ return }
 	process.uptime = process.uptime || noop;
 	process.cpuUsage = process.cpuUsage || noop;
@@ -23,7 +27,7 @@ Gun.on('opt', function(root){
 	var S = +new Date, W;
 	var obj_ify = function(o){try{o = JSON.parse(o)}catch(e){o={}};return o;}
 	setTimeout(function(){
-		root.stats = obj_ify((fs.existsSync(__dirname+'/../stats.'+(root.opt.file||file)) && fs.readFileSync(__dirname+'/../stats.'+(root.opt.file||file)).toString())) || {};
+		root.stats = obj_ify((fs.existsSync(__dirname+'/../stats.'+file) && fs.readFileSync(__dirname+'/../stats.'+file).toString())) || {};
 		root.stats.up = root.stats.up || {};
 		root.stats.up.start = root.stats.up.start || +(new Date);
 		root.stats.up.count = (root.stats.up.count || 0) + 1;
@@ -62,10 +66,10 @@ Gun.on('opt', function(root){
 			root.opt.store.stats = {get:{time:{}, count:0}, put: {time:{}, count:0}}; // reset
 		}
 		JSON.stringifyAsync(stats, function(err, raw){ if(err){ return } W = true;
-			fs.writeFile(__dirname+'/../stats.'+(root.opt.file||file), raw, function(err){ W = false; err && console.log(console.STAT.err = err); console.STAT && console.STAT(S, +new Date - S, 'stats stash') });
+			fs.writeFile(__dirname+'/../stats.'+file, raw, function(err){ W = false; err && console.log(console.STAT.err = err); console.STAT && console.STAT(S, +new Date - S, 'stats stash') });
 		});
 
-		//exec("top -b -n 1", function(err, out){ out && fs.writeFile(__dirname+'/../stats.top.'+(root.opt.file||file), out, noop) }); // was it really seriously actually this?
+		//exec("top -b -n 1", function(err, out){ out && fs.writeFile(__dirname+'/../stats.top.'+file, out, noop) }); // was it really seriously actually this?
 	//}, 1000 * 15);
 	}, 1000 * 5);
 });

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -6,12 +6,12 @@ Gun.on('opt', function(root){
 	if(typeof process === 'undefined'){ return }
 	if(typeof require === 'undefined'){ return }
 	if(false === root.opt.stats){ return }
-	// var file = root.opt.file || 'radata';
-	var file = 'radata';
+	var path = require('path') || {};
+	var file = root.opt.file ? path.resolve(root.opt.file).split(path.sep).slice(-1)[0] : 'radata';
 	var noop = function(){};
 	var os = require('os') || {};
 	var fs = require('fs') || {};
-	fs.existsSync = fs.existsSync || require('path').existsSync;
+	fs.existsSync = fs.existsSync || path.existsSync;
 	if(!fs.existsSync){ return }
 	if(!process){ return }
 	process.uptime = process.uptime || noop;

--- a/lib/stats.js
+++ b/lib/stats.js
@@ -13,9 +13,6 @@ Gun.on('opt', function(root){
 	var fs = require('fs') || {};
 	fs.existsSync = fs.existsSync || require('path').existsSync;
 	if(!fs.existsSync){ return }
-	if(!fs.existsSync(__dirname+'/../stats.'+file)){
-		fs.writeFileSync(__dirname+'/../stats.'+file, '')
-	}
 	if(!process){ return }
 	process.uptime = process.uptime || noop;
 	process.cpuUsage = process.cpuUsage || noop;


### PR DESCRIPTION
`fs.writeFile(__dirname+'/../stats.'+(root.opt.file || file), raw, function(err){ W = false; err && console.log(console.STAT.err = err); console.STAT && console.STAT(S, +new Date - S, 'stats stash') });`

the above line is what creates the following error:
`Error: ENOENT: no such file or directory, open 'C:\Project\gundb\tests\node_modules\gun\stats.C:\Project\gundb\testingFolder'`

does the stats.radata need to be the root.opt.file? because if someone inputs a file directory like C:\some\path\here, it will make the stats file into 'stats.C:\some\path\here' which i think is the problem for fs.write functions. what i did is create the stats.radata file only in the gun directory, tested it and i get no errors now. will this be satisfactory?