### PR TITLE
Change Dockerfile `python` package to `python3`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:14-alpine as builder
 RUN mkdir /work
 WORKDIR /work
-RUN apk add --no-cache alpine-sdk python
+RUN apk add --no-cache alpine-sdk python3
 COPY package*.json ./
 RUN mkdir -p node_modules
 RUN npm ci --only=production


### PR DESCRIPTION
As of version 3.12, the python package will no longer be supported in favor of explicitly chosen packages python2 or python3.

For more information regarding this change, refer to the following commit:
- [https://git.alpinelinux.org/aports/commit/?id=5ad0ec7d](https://git.alpinelinux.org/aports/commit/?id=5ad0ec7d)

or discussion on the docker-alpine repository:
- [https://github.com/alpinelinux/docker-alpine/issues/83#issuecomment-641172146](https://github.com/alpinelinux/docker-alpine/issues/83#issuecomment-641172146)