### PR TITLE
ReactNative/Expo fix for SEA

### DIFF
--- a/lib/mobile.js
+++ b/lib/mobile.js
@@ -1,0 +1,5 @@
+import Buffer from "buffer";
+import { TextEncoder, TextDecoder } from "text-encoding";
+global.Buffer = global.Buffer || Buffer.Buffer;
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;


### PR DESCRIPTION
SEA can be used in any react native/ expo by importing `lib/mobile.js` before importing SEA like the one below. This removes the dynamic dependency error.
```
import shim from "gun/lib/mobile"
import Gun from "gun/gun"
import SEA from "gun/sea"