### PR TITLE
put validation: adding '-Infinity' as an invalid case; speeding validation up

### DIFF
--- a/gun.js
+++ b/gun.js
@@ -134,15 +134,16 @@
 		// or a soul relation. Arrays need special algorithms to handle concurrency,
 		// so they are not supported directly. Use an extension that supports them if
 		// needed but research their problems first.
-		module.exports = (v) =>
+		module.exports = function (v) {
 		  // "deletes", nulling out keys.
-		  v === null ||
-		  "string" === typeof v ||
-		  "boolean" === typeof v ||
-		  // we want +/- Infinity to be, but JSON does not support it, sad face.
-		  // can you guess what v === v checks for? ;)
-		  ("number" === typeof v && v != Infinity && v != -Infinity && v === v) ||
-		  (v && "string" == typeof v["#"] && Object.keys(v).length === 1 && v["#"]);
+		  return v === null ||
+			"string" === typeof v ||
+			"boolean" === typeof v ||
+			// we want +/- Infinity to be, but JSON does not support it, sad face.
+			// can you guess what v === v checks for? ;)
+			("number" === typeof v && v != Infinity && v != -Infinity && v === v) ||
+			(v && "string" == typeof v["#"] && Object.keys(v).length === 1 && v["#"]);
+		}
 	})(USE, './valid');
 
 	;USE(function(module){

--- a/gun.js
+++ b/gun.js
@@ -130,7 +130,6 @@
 	})(USE, './onto');
 
 	;USE(function(module){
-		USE('./shim');
 		// Valid values are a subset of JSON: null, binary, number (!Infinity), text,
 		// or a soul relation. Arrays need special algorithms to handle concurrency,
 		// so they are not supported directly. Use an extension that supports them if

--- a/gun.js
+++ b/gun.js
@@ -137,16 +137,12 @@
 		module.exports = (v) =>
 		  // "deletes", nulling out keys.
 		  v === null ||
-		  (v !== undefined &&
-		    ("string" === typeof v ||
-		      "boolean" === typeof v ||
-		      // we want +/- Infinity to be, but JSON does not support it, sad face.
-		      // can you guess what v === v checks for? ;)
-		      ("number" === typeof v && v != Infinity && v != -Infinity && v === v) ||
-		      (v &&
-			"string" == typeof v["#"] &&
-			Object.keys(v).length === 1 &&
-			v["#"])));
+		  "string" === typeof v ||
+		  "boolean" === typeof v ||
+		  // we want +/- Infinity to be, but JSON does not support it, sad face.
+		  // can you guess what v === v checks for? ;)
+		  ("number" === typeof v && v != Infinity && v != -Infinity && v === v) ||
+		  (v && "string" == typeof v["#"] && Object.keys(v).length === 1 && v["#"]);
 	})(USE, './valid');
 
 	;USE(function(module){

--- a/gun.js
+++ b/gun.js
@@ -131,19 +131,23 @@
 
 	;USE(function(module){
 		USE('./shim');
-		module.exports = function(v){ // Valid values are a subset of JSON: null, binary, number (!Infinity), text, or a soul relation. Arrays need special algorithms to handle concurrency, so they are not supported directly. Use an extension that supports them if needed but research their problems first.
-			if(v === undefined){ return false }
-			if(v === null){ return true } // "deletes", nulling out keys.
-			if(v === Infinity){ return false } // we want this to be, but JSON does not support it, sad face.
-			if(v !== v){ return false } // can you guess what this checks for? ;)
-			if('string' == typeof v // text!
-			|| 'boolean' == typeof v
-			|| 'number' == typeof v){
-				return true; // simple values are valid.
-			}
-			if(v && ('string' == typeof (v['#']||0)) && Object.empty(v, ['#'])){ return v['#'] } // is link
-			return false; // If not, everything else remaining is an invalid data type. Custom extensions can be built on top of these primitives to support other types.
-		}
+		// Valid values are a subset of JSON: null, binary, number (!Infinity), text,
+		// or a soul relation. Arrays need special algorithms to handle concurrency,
+		// so they are not supported directly. Use an extension that supports them if
+		// needed but research their problems first.
+		module.exports = (v) =>
+		  // "deletes", nulling out keys.
+		  v === null ||
+		  (v !== undefined &&
+		    ("string" === typeof v ||
+		      "boolean" === typeof v ||
+		      // we want +/- Infinity to be, but JSON does not support it, sad face.
+		      // can you guess what v === v checks for? ;)
+		      ("number" === typeof v && v != Infinity && v != -Infinity && v === v) ||
+		      (v &&
+			"string" == typeof v["#"] &&
+			Object.keys(v).length === 1 &&
+			v["#"])));
 	})(USE, './valid');
 
 	;USE(function(module){

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -164,16 +164,12 @@
 	  DEP("val.is");
 	  // "deletes", nulling out keys.
 	  v === null ||
-	    (v !== undefined &&
-	      ("string" === typeof v ||
-		"boolean" === typeof v ||
-		// we want +/- Infinity to be, but JSON does not support it, sad face.
-		// can you guess what v === v checks for? ;)
-		("number" === typeof v && v != Infinity && v != -Infinity && v === v) ||
-		(v &&
-		  "string" == typeof v["#"] &&
-		  Object.keys(v).length === 1 &&
-		  v["#"])));
+	  "string" === typeof v ||
+	  "boolean" === typeof v ||
+	  // we want +/- Infinity to be, but JSON does not support it, sad face.
+	  // can you guess what v === v checks for? ;)
+	  ("number" === typeof v && v != Infinity && v != -Infinity && v === v) ||
+	  (v && "string" == typeof v["#"] && Object.keys(v).length === 1 && v["#"]);
 	};
 	Val.link = Val.rel = {_: '#'};
 	;(function(){

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -160,16 +160,16 @@
 	// or a soul relation. Arrays need special algorithms to handle concurrency,
 	// so they are not supported directly. Use an extension that supports them if
 	// needed but research their problems first.
-	Val.is = (v) => {
+	Val.is = function (v) {
 	  DEP("val.is");
 	  // "deletes", nulling out keys.
-	  v === null ||
-	  "string" === typeof v ||
-	  "boolean" === typeof v ||
-	  // we want +/- Infinity to be, but JSON does not support it, sad face.
-	  // can you guess what v === v checks for? ;)
-	  ("number" === typeof v && v != Infinity && v != -Infinity && v === v) ||
-	  (v && "string" == typeof v["#"] && Object.keys(v).length === 1 && v["#"]);
+	  return v === null ||
+		"string" === typeof v ||
+		"boolean" === typeof v ||
+		// we want +/- Infinity to be, but JSON does not support it, sad face.
+		// can you guess what v === v checks for? ;)
+		("number" === typeof v && v != Infinity && v != -Infinity && v === v) ||
+		(v && "string" == typeof v["#"] && Object.keys(v).length === 1 && v["#"]);
 	};
 	Val.link = Val.rel = {_: '#'};
 	;(function(){

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -156,17 +156,25 @@
 	var obj = Type.obj, obj_is = obj.is, obj_has = obj.has, obj_map = obj.map;
 
 	var Val = {};
-	Val.is = function(v){ DEP('val.is'); // Valid values are a subset of JSON: null, binary, number (!Infinity), text, or a soul relation. Arrays need special algorithms to handle concurrency, so they are not supported directly. Use an extension that supports them if needed but research their problems first.
-		if(v === u){ return false }
-		if(v === null){ return true } // "deletes", nulling out keys.
-		if(v === Infinity){ return false } // we want this to be, but JSON does not support it, sad face.
-		if(text_is(v) // by "text" we mean strings.
-		|| bi_is(v) // by "binary" we mean boolean.
-		|| num_is(v)){ // by "number" we mean integers or decimals.
-			return true; // simple values are valid.
-		}
-		return Val.link.is(v) || false; // is the value a soul relation? Then it is valid and return it. If not, everything else remaining is an invalid data type. Custom extensions can be built on top of these primitives to support other types.
-	}
+	// Valid values are a subset of JSON: null, binary, number (!Infinity), text,
+	// or a soul relation. Arrays need special algorithms to handle concurrency,
+	// so they are not supported directly. Use an extension that supports them if
+	// needed but research their problems first.
+	Val.is = (v) => {
+	  DEP("val.is");
+	  // "deletes", nulling out keys.
+	  v === null ||
+	    (v !== undefined &&
+	      ("string" === typeof v ||
+		"boolean" === typeof v ||
+		// we want +/- Infinity to be, but JSON does not support it, sad face.
+		// can you guess what v === v checks for? ;)
+		("number" === typeof v && v != Infinity && v != -Infinity && v === v) ||
+		(v &&
+		  "string" == typeof v["#"] &&
+		  Object.keys(v).length === 1 &&
+		  v["#"])));
+	};
 	Val.link = Val.rel = {_: '#'};
 	;(function(){
 		Val.link.is = function(v){ DEP('val.link.is'); // this defines whether an object is a soul relation or not, they look like this: {'#': 'UUID'}

--- a/src/valid.js
+++ b/src/valid.js
@@ -1,6 +1,3 @@
-
-require('./shim');
-
 // Valid values are a subset of JSON: null, binary, number (!Infinity), text,
 // or a soul relation. Arrays need special algorithms to handle concurrency,
 // so they are not supported directly. Use an extension that supports them if

--- a/src/valid.js
+++ b/src/valid.js
@@ -2,12 +2,13 @@
 // or a soul relation. Arrays need special algorithms to handle concurrency,
 // so they are not supported directly. Use an extension that supports them if
 // needed but research their problems first.
-module.exports = (v) =>
+module.exports = function (v) {
   // "deletes", nulling out keys.
-  v === null ||
-  "string" === typeof v ||
-  "boolean" === typeof v ||
-  // we want +/- Infinity to be, but JSON does not support it, sad face.
-  // can you guess what v === v checks for? ;)
-  ("number" === typeof v && v != Infinity && v != -Infinity && v === v) ||
-  (v && "string" == typeof v["#"] && Object.keys(v).length === 1 && v["#"]);
+  return v === null ||
+    "string" === typeof v ||
+    "boolean" === typeof v ||
+    // we want +/- Infinity to be, but JSON does not support it, sad face.
+    // can you guess what v === v checks for? ;)
+    ("number" === typeof v && v != Infinity && v != -Infinity && v === v) ||
+    (v && "string" == typeof v["#"] && Object.keys(v).length === 1 && v["#"]);
+}

--- a/src/valid.js
+++ b/src/valid.js
@@ -1,16 +1,20 @@
 
 require('./shim');
-module.exports = function(v){ // Valid values are a subset of JSON: null, binary, number (!Infinity), text, or a soul relation. Arrays need special algorithms to handle concurrency, so they are not supported directly. Use an extension that supports them if needed but research their problems first.
-	if(v === undefined){ return false }
-	if(v === null){ return true } // "deletes", nulling out keys.
-	if(v === Infinity){ return false } // we want this to be, but JSON does not support it, sad face.
-	if(v !== v){ return false } // can you guess what this checks for? ;)
-	if('string' == typeof v // text!
-	|| 'boolean' == typeof v
-	|| 'number' == typeof v){
-		return true; // simple values are valid.
-	}
-	if(v && ('string' == typeof (v['#']||0)) && Object.empty(v, ['#'])){ return v['#'] } // is link
-	return false; // If not, everything else remaining is an invalid data type. Custom extensions can be built on top of these primitives to support other types.
-}
-	
+
+// Valid values are a subset of JSON: null, binary, number (!Infinity), text,
+// or a soul relation. Arrays need special algorithms to handle concurrency,
+// so they are not supported directly. Use an extension that supports them if
+// needed but research their problems first.
+module.exports = (v) =>
+  // "deletes", nulling out keys.
+  v === null ||
+  (v !== undefined &&
+    ("string" === typeof v ||
+      "boolean" === typeof v ||
+      // we want +/- Infinity to be, but JSON does not support it, sad face.
+      // can you guess what v === v checks for? ;)
+      ("number" === typeof v && v != Infinity && v != -Infinity && v === v) ||
+      (v &&
+        "string" == typeof v["#"] &&
+        Object.keys(v).length === 1 &&
+        v["#"])));

--- a/src/valid.js
+++ b/src/valid.js
@@ -5,13 +5,9 @@
 module.exports = (v) =>
   // "deletes", nulling out keys.
   v === null ||
-  (v !== undefined &&
-    ("string" === typeof v ||
-      "boolean" === typeof v ||
-      // we want +/- Infinity to be, but JSON does not support it, sad face.
-      // can you guess what v === v checks for? ;)
-      ("number" === typeof v && v != Infinity && v != -Infinity && v === v) ||
-      (v &&
-        "string" == typeof v["#"] &&
-        Object.keys(v).length === 1 &&
-        v["#"])));
+  "string" === typeof v ||
+  "boolean" === typeof v ||
+  // we want +/- Infinity to be, but JSON does not support it, sad face.
+  // can you guess what v === v checks for? ;)
+  ("number" === typeof v && v != Infinity && v != -Infinity && v === v) ||
+  (v && "string" == typeof v["#"] && Object.keys(v).length === 1 && v["#"]);

--- a/test/common.js
+++ b/test/common.js
@@ -518,6 +518,7 @@ describe('Gun', function(){
 				expect(Gun.is('')).to.be(false);
 				expect(Gun.is('a')).to.be(false);
 				expect(Gun.is(Infinity)).to.be(false);
+				expect(Gun.is(-Infinity)).to.be(false);
 				expect(Gun.is(NaN)).to.be(false);
 				expect(Gun.is([])).to.be(false);
 				expect(Gun.is([1])).to.be(false);
@@ -535,6 +536,7 @@ describe('Gun', function(){
 				expect(Gun.valid({'#':'somesoulidhere'})).to.be('somesoulidhere');
 				expect(Gun.valid({'#':'somesoulidhere', and: 'nope'})).to.be(false);
 				expect(Gun.valid(Infinity)).to.be(false); // boohoo :(
+				expect(Gun.valid(-Infinity)).to.be(false); // boohoo :(
 				expect(Gun.valid(NaN)).to.be(false);
 				expect(Gun.valid([])).to.be(false);
 				expect(Gun.valid([1])).to.be(false);
@@ -554,6 +556,7 @@ describe('Gun', function(){
 				expect('string' == typeof Gun.valid(0)).to.be(false);
 				expect('string' == typeof Gun.valid(1)).to.be(false);
 				expect('string' == typeof Gun.valid(Infinity)).to.be(false); // boohoo :(
+				expect('string' == typeof Gun.valid(-Infinity)).to.be(false); // boohoo :(
 				expect('string' == typeof Gun.valid(NaN)).to.be(false);
 				expect('string' == typeof Gun.valid([])).to.be(false);
 				expect('string' == typeof Gun.valid([1])).to.be(false);


### PR DESCRIPTION
Adding '-Infinity' as an invalid case, not handled before
Skipping extra checks until needed (like NaN, Infinity)
Checking for 'null' first as for more common case than invalid 'undefined'
Fixing tests to handle -Infinity