### PR TITLE
lib/ison: Use setTimeout instead of setImmediate. 

### DIFF
--- a/lib/ison.js
+++ b/lib/ison.js
@@ -278,7 +278,7 @@ let stringifyWrapper = (value, replacer, space, intensity, callback) => {
   let g = rs.next();
 
   let yieldCPU = () => {
-    setImmediate(() => {
+    setTimeout(() => {
       g = rs.next();
       if (g && g.done === true) {
         // Reinitializing the values at the end of API call
@@ -291,7 +291,7 @@ let stringifyWrapper = (value, replacer, space, intensity, callback) => {
           return callback(null, yielding);
       }
       yieldCPU();
-    });
+    }, 0);
   };
   return yieldCPU();
 };
@@ -592,7 +592,7 @@ let parseWrapper = (text, reviver, intensity, cb) => {
 
   // Main yield control logic.
   let yieldCPU = () => {
-    setImmediate(() => {
+    setTimeout(() => {
       gen = rs.next();
 
       if (gen && gen.done === true) {
@@ -618,7 +618,7 @@ let parseWrapper = (text, reviver, intensity, cb) => {
         }
       }
       yieldCPU();
-    });
+    }), 0;
   };
   return yieldCPU();
 };


### PR DESCRIPTION
Allows the use of IndexDB in browsers