### PR TITLE
fix(npm): change glob preventing GunDataNode.d.ts

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,5 @@
 *.ts
 /temp/
 !*.d.ts
-*data*
+*.radata
 isolate-*


### PR DESCRIPTION
Changes from [cd45008433759cb65476e42eabc8b076d53a9f6d](https://github.com/amark/gun/commit/cd45008433759cb65476e42eabc8b076d53a9f6d) caused the [GunDataNode.d.ts](https://github.com/amark/gun/blob/master/types/gun/GunDataNode.d.ts) file from being included in the NPM package.

Can be confirmed by using:

```bash
npx npm-packlist
```

This fix assumes the only file unwanted is `stats.radata`. However, this also causes the following files to be **included**:
```
test/panic/axe/data_balance_webrtc.js
test/panic/axe/data_balance.js
```

I left them as included, because other test files are included in the package. However, in my opinion, the npm package should not include test files 🤷‍♂️ 