### PR TITLE
Heroku fixes

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,6 +1,5 @@
 {
   "name": "gun-server",
-  "stack": "heroku-18",
   "website": "http://gun.eco/",
   "repository": "https://github.com/amark/gun",
   "logo": "https://avatars3.githubusercontent.com/u/8811914",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "ios": "browser.ios.js",
   "android": "browser.android.js",
   "scripts": {
-    "prepare": "npm run unbuildSea && npm run unbuild",
     "start": "node --prof examples/http.js",
     "debug": "node --prof-process --preprocess -j isolate*.log > v8data.json && rm isolate*.log && echo 'drag & drop ./v8data.json into https://mapbox.github.io/flamebearer/'",
     "https": "HTTPS_KEY=test/https/server.key HTTPS_CERT=test/https/server.crt npm start",


### PR DESCRIPTION
Removed 'stack' parameter to enable using the latest Heroku stack. This will allow new one-click deploys to use the latest Heroku stack, and avoid potential security issues.