### PR TITLE
Add a function to perform an asynchronous "gun.get()" + tests

### DIFF
--- a/lib/async-get.js
+++ b/lib/async-get.js
@@ -1,0 +1,49 @@
+let gun;
+
+let used = false;
+
+Object.prototype.list = function (data) {
+
+    let all = Object.entries(this);
+
+    all.shift();
+
+    let mapped = []
+
+    for(let i = 0; i < all.length; i++) {
+        mapped.push(all[i][1]);
+    }
+    
+    return mapped;
+}
+
+const inject = (instance) => {
+    used = true;
+    gun = instance;
+}
+
+const get = async (what) => {
+
+    if (!used) {
+        console.log(new Error("You must inject Gun into the packager by passing its reference to the `inject` function."))
+        process.exit(1);
+    }
+
+    if (!what) {
+        console.log(new Error("You did not provide any soul. EXAMPLE: let whatever = await get(<soul>);"))
+        process.exit(1);
+    }
+
+    let result;
+    await gun.get(what).once(data => {
+        result = data;
+    })
+
+    return await result;
+
+}
+
+module.exports = {
+    get:get,
+    inject: inject
+}

--- a/test/async-get/index.js
+++ b/test/async-get/index.js
@@ -1,0 +1,29 @@
+const Gun = require("../../index");
+const {get, inject} = require("../../lib/async-get");
+
+const gun = Gun({ peers:["https://gunpoint.herokuapp.com/gun"] });
+
+// Add test data!
+for (let i = 0; i < 5; i++) {
+    gun.get("this is a test").set(`Hello, ${i}`)
+}
+
+(async () => {
+
+    /*
+
+        I had to find a way to allow the user to have HIS gun configuration used 
+        with the peers he decided to use, and so on...
+
+        So I created the `inject` function which allow to use 
+        YOUR custom configuration. 
+
+    */ 
+    inject(gun);
+
+
+    let data = await get("this is a test");
+
+    console.log(data.list())
+
+})();


### PR DESCRIPTION
# Asynchronous  "gun.get()"
> DISCLAIMER: this functionnality is **optional** meaning that I have not added it to the `/src` folder which bundles gun itself. The source code is instead in `/lib` meaning that it can be imported if the user wants.

The goal of this PR is to introduce a way to quicly query the database asynchronously. I also included a `inject` function to allow the user to use its Gun configuration (eg. `const gun = Gun({ peers: ["https://gunpoint.herokuapp.com/gun"] })`. In order to use it you must just pass it to the function and it'll be automatically used.

## Example
This function allows you to write:

```js
let data = await get(`this is a test`);
console.log(data);

/*
{
  _: {
    '#': 'this is a test',
    '>': {
      l4pqkx1ihbPFwyN: 1655910875718.001,
      l4pqkx1jHgZS44c: 1655910875719.001,
      l4pqkx1j02jUyiCK6R: 1655910875719.003,
      l4pqkx1j05JBa74d2: 1655910875719.0051,
      l4pqkx1j08cv7cc14: 1655910875719.007,
      l4pqkba002j9uQhSOn: 1655910847513,
      l4pqkba07557SmB: 1655910847512.001,
      l4pqkba101a31UNqzR: 1655910847513.002,
      l4pqkba103tKkEIL5s: 1655910847513.004,
      l4pqkba106nVTfaeAD: 1655910847513.006
    }
  },
  l4pqkx1ihbPFwyN: 'Hello, 0',
  l4pqkx1jHgZS44c: 'Hello, 1',
  l4pqkx1j02jUyiCK6R: 'Hello, 2',
  l4pqkx1j05JBa74d2: 'Hello, 3',
  l4pqkx1j08cv7cc14: 'Hello, 4',
  l4pqkba002j9uQhSOn: 'Hello, 1',
  l4pqkba07557SmB: 'Hello, 0',
  l4pqkba101a31UNqzR: 'Hello, 2',
  l4pqkba103tKkEIL5s: 'Hello, 3',
  l4pqkba106nVTfaeAD: 'Hello, 4'
}
*/

console.log(data.list());
/*
[
  'Hello, 0', 'Hello, 1',
  'Hello, 2', 'Hello, 3',
  'Hello, 4', 'Hello, 1',
  'Hello, 0', 'Hello, 2',
  'Hello, 3', 'Hello, 4'
]
*/
```