### PR TITLE
SEA - Update sea.work to support hex

### DIFF
--- a/sea/index.js
+++ b/sea/index.js
@@ -68,7 +68,14 @@
     }
     check.hash = function(eve, msg, val, key, soul, at, no){
       SEA.work(val, null, function(data){
+        function hexToBase64(hexStr) {
+          let base64 = "";
+          for(let i = 0; i < hexStr.length; i++) {
+            base64 += !(i - 1 & 1) ? String.fromCharCode(parseInt(hexStr.substring(i - 1, i + 1), 16)) : ""}
+          return btoa(base64);}  
         if(data && data === key.split('#').slice(-1)[0]){ return eve.to.next(msg) }
+          else if (data && data === hexToBase64(key.split('#').slice(-1)[0])){ 
+          return eve.to.next(msg) }
         no("Data hash not same as hash!");
       }, {name: 'SHA-256'});
     }


### PR DESCRIPTION
This would encode to hex:
```var data = "hello world";
var hash1 = await SEA.work(data, null, null, {name: "SHA-256",encode:
"hex"});
```
but this would not verify correctly:
```gun.get('#').get(hash1).put(data);```

This PR will first check base64 (current functionality) and if it fails now it will fall back and check hex.