### PR TITLE
Make SEA work in service worker

### DIFF
--- a/sea.js
+++ b/sea.js
@@ -1,5 +1,7 @@
 ;(function(){
 
+  var window = this || self || window;
+
   /* UNBUILD */
   function USE(arg, req){
     return req? require(arg) : arg.slice? USE[R(arg)] : function(mod, path){


### PR DESCRIPTION
Service workers have no window object. Without this fix, SEA in service worker throws "window is not defined".