### PR TITLE
Unfinished webrtc negotiation rework

### DIFF
--- a/lib/webrtc.js
+++ b/lib/webrtc.js
@@ -34,19 +34,34 @@
     opt.rtc.sdp = opt.rtc.sdp || {mandatory: {OfferToReceiveAudio: false, OfferToReceiveVideo: false}};
     opt.rtc.max = opt.rtc.max || 55; // is this a magic number? // For Future WebRTC notes: Chrome 500 max limit, however 256 likely - FF "none", webtorrent does 55 per torrent.
     opt.rtc.room = opt.rtc.room || Gun.window && (location.hash.slice(1) || location.pathname.slice(1));
+		var room = () => root.$.get('/RTC/'+opt.rtc.room+'<?99');
     opt.announce = function(to){
 			opt.rtc.start = +new Date; // handle room logic:
-			root.$.get('/RTC/'+opt.rtc.room+'<?99').get('+').put(opt.pid, function(ack){
+			room().get('+').put(opt.pid, function(ack){
 				if(!ack.ok || !ack.ok.rtc){ return }
-				open(ack);
-			}, {acks: opt.rtc.max}).on(function(last,key, msg){
+				room().get('+'+ack.ok.rtc.id).put(opt.pid, function(ack){
+					if(!ack.ok || !ack.ok.rtc){ return }
+					open(ack);
+				});
+			}, {acks: opt.rtc.max}).on(function (last,key, msg){
 				if(last === opt.pid || opt.rtc.start > msg.put['>']){ return }
+				room().get('+'+last).put(opt.pid, function(ack){
+					if(!ack.ok || !ack.ok.rtc){ return }
+					open({'#': ''+ack['#'], ok: {rtc: {id: last, respect: true}}});
+				});
+				root.on('out', {'@': msg['#'], ok: {rtc: {id: opt.pid}}});
+			});
+			// TODO: implement negotiation setup here
+			// TODO: order greetings in this function
+			room().get('+'+opt.pid).on(function(last, key, msg){
+				if(opt.rtc.start > msg.put['>']){ return }
 				open({'#': ''+msg['#'], ok: {rtc: {id: last}}});
 			});
     };
 
 		var mesh = opt.mesh = opt.mesh || Gun.Mesh(root);
 		root.on('create', function(at){
+			console.log(opt.pid);
 			this.to.next(at);
 			setTimeout(opt.announce, 1);
 		});
@@ -56,57 +71,69 @@
 			if(!msg.ok){ return }
 			var rtc = msg.ok.rtc, peer, tmp;
 			if(!rtc || !rtc.id || rtc.id === opt.pid){ return }
-			//console.log("webrtc:", JSON.stringify(msg));
+			peer = opt.peers[rtc.id] || open[rtc.id];
+			if(!peer){
+				(peer = new opt.RTCPeerConnection(opt.rtc)).id = rtc.id;
+				var wire = peer.wire = peer.createDataChannel('dc', opt.rtc.dataChannel);
+				open[rtc.id] = peer;
+				wire.to = setTimeout(function(){delete open[rtc.id]},1000*60);
+				wire.onclose = function(){ mesh.bye(peer) };
+				wire.onerror = function(err){ };
+				wire.onopen = function(e){
+					delete open[rtc.id];
+					mesh.hi(peer);
+				}
+				wire.onmessage = function(msg){
+					if(!msg){ return }
+					mesh.hear(msg.data || msg, peer);
+				};
+				peer.onicecandidate = function(e){ // source: EasyRTC!
+					if(!e.candidate){ return }
+					// root.on('out', {'@': msg['#'], ok: {rtc: {candidate: e.candidate, id: opt.pid}}});
+					root.$.get('/RTC/'+opt.rtc.room+'<?99').get('='+rtc.id).put({candidate: e.candidate, id: opt.pid}); //previous data has to be erased here, or use pub-sub
+				}
+				peer.ondatachannel = function(e){
+					var rc = e.channel;
+					rc.onmessage = wire.onmessage;
+					rc.onopen = wire.onopen;
+					rc.onclose = wire.onclose;
+				}
+			}
 			if(tmp = rtc.answer){
-				if(!(peer = opt.peers[rtc.id] || open[rtc.id]) || peer.remoteSet){ return }
 				tmp.sdp = tmp.sdp.replace(/\\r\\n/g, '\r\n');
-				return peer.setRemoteDescription(peer.remoteSet = new opt.RTCSessionDescription(tmp)); 
+				return peer.setRemoteDescription(new opt.RTCSessionDescription(tmp)); 
 			}
-			if(tmp = rtc.candidate){
-				peer = opt.peers[rtc.id] || open[rtc.id] || open({ok: {rtc: {id: rtc.id}}});
-				return peer.addIceCandidate(new opt.RTCIceCandidate(tmp));
-			}
-			//if(opt.peers[rtc.id]){ return }
-			if(open[rtc.id]){ return }
-			(peer = new opt.RTCPeerConnection(opt.rtc)).id = rtc.id;
-			var wire = peer.wire = peer.createDataChannel('dc', opt.rtc.dataChannel);
-			open[rtc.id] = peer;
-			wire.to = setTimeout(function(){delete open[rtc.id]},1000*60);
-			wire.onclose = function(){ mesh.bye(peer) };
-			wire.onerror = function(err){ };
-			wire.onopen = function(e){
-				delete open[rtc.id];
-				mesh.hi(peer);
-			}
-			wire.onmessage = function(msg){
-				if(!msg){ return }
-				//console.log('via rtc');
-				mesh.hear(msg.data || msg, peer);
-			};
-			peer.onicecandidate = function(e){ // source: EasyRTC!
-        if(!e.candidate){ return }
-        root.on('out', {'@': msg['#'], ok: {rtc: {candidate: e.candidate, id: opt.pid}}});
-			}
-			peer.ondatachannel = function(e){
-				var rc = e.channel;
-				rc.onmessage = wire.onmessage;
-				rc.onopen = wire.onopen;
-				rc.onclose = wire.onclose;
-			}
+			if(tmp = rtc.candidate){ return peer.addIceCandidate(new opt.RTCIceCandidate(tmp)) }
 			if(tmp = rtc.offer){
 				rtc.offer.sdp = rtc.offer.sdp.replace(/\\r\\n/g, '\r\n')
 				peer.setRemoteDescription(new opt.RTCSessionDescription(tmp)); 
 				peer.createAnswer(function(answer){
 					peer.setLocalDescription(answer);
-					root.on('out', {'@': msg['#'], ok: {rtc: {answer: answer, id: opt.pid}}});
+					// root.on('out', {'@': msg['#'], ok: {rtc: {answer: answer, id: opt.pid}}});
+					root.$.get('/RTC/'+opt.rtc.room+'<?99').get('='+rtc.id).put({answer: answer, id: opt.pid});
 				}, function(){}, opt.rtc.sdp);
 				return;
 			}
-			peer.createOffer(function(offer){
-				peer.setLocalDescription(offer);
-				root.on('out', {'@': msg['#'], '#': root.ask(open), ok: {rtc: {offer: offer, id: opt.pid}}});
-			}, function(){}, opt.rtc.sdp);
-			return peer;
+			if(tmp = rtc.negotiationneeded){
+				peer.createOffer(function(offer){
+					peer.setLocalDescription(offer);
+					// root.on('out', {'@': msg['#'], '#': root.ask(open), ok: {rtc: {offer: offer, id: opt.pid}}});
+					console.log('sending offer')
+					root.$.get('/RTC/'+opt.rtc.room+'<?99').get('='+rtc.id).put({offer: offer, id: opt.pid});
+				}, function(){}, opt.rtc.sdp);
+				return;
+			}
+			// room join
+			peer.negotiate = msg['#'];
+			if(rtc.respect){ peer.respect = true }
+			console.log('sending to', msg['#']);
+			// setTimeout(function() {
+			// root.on('out', {'@': msg['#'], ok: {rtc: {id: opt.pid}}}); //FIXME: does not send
+			// }, 1);
+			setTimeout(function() {
+			root.on('out', {'@': msg['#'], ok: {rtc: {id: opt.pid}}}); //FIXME: does not send
+			root.on('out', {'@': msg['#'], ok: {rtc: {id: 'heh'}}}); //FIXME: does not send
+			}, 10);
 		}
 	});
 }());


### PR DESCRIPTION
### Why
To be able to use single GUNs peer connection for sending video and audio in a meeting app

### How
Implement [perfect negotiation](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Perfect_negotiation) to be able to add or remove new application specific video/audio/data channels with proper renegotiation and see incoming streams on the other side

### Current state
Abandoned. Broken and I don't even recall why. afair it is because I was only able to send one ACK for a single message

### Initial idea (afair)
Per each peer we need separate bidirectional signalling channel so that both sides could trigger renegotiation when adding new audio/video streams. So I tried to implement bidirectional channel via ACKs, but was only able to send only one in a given "channel" (gundb specifics?)

### Why make pull request then?
atm I abandoned the project. If someone else wants the same feature they can maybe start from here. Or this is gibberish and can be ignored.


In any case. If you will decide to continue from here. You will probably first have to implement bidirectional communication between selected peers first and after that perfect negotiation will be easy peasy
