### PR TITLE
Allow Dockerfile to auto-update Node version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # install packages
-FROM node:14-alpine as builder
+FROM node:lts-alpine as builder
 RUN mkdir /work
 WORKDIR /work
 RUN apk add --no-cache alpine-sdk python3
@@ -8,7 +8,7 @@ RUN mkdir -p node_modules
 RUN npm ci --only=production
 
 # fresh image without dev packages
-FROM node:14-alpine
+FROM node:lts-alpine
 # build-time metadata as defined at http://label-schema.org
 ARG BUILD_DATE
 ARG VCS_REF


### PR DESCRIPTION
The Docker version of GUN is running on Node 14. I don't see any reason not to upgrade that to Node 18 and get free performance and feature improvements.

Instead of fixing it to Node 18, I have chosen the version that automatically updates to the newest LTS version of Node, for maximum forgettability :)