### PR TITLE
fix: change type to string instead of literal newPassword

### DIFF
--- a/types/sea/OptionsUserAuth.d.ts
+++ b/types/sea/OptionsUserAuth.d.ts
@@ -1,1 +1,1 @@
-export type OptionsUserAuth = { change: 'newPassword' };
+export type OptionsUserAuth = { change: string };


### PR DESCRIPTION
Small type fix to change the type to string instead of "newPassword" literal.