### PR TITLE
lets play nice with react-native(metro)

### DIFF
--- a/gun.js
+++ b/gun.js
@@ -2,7 +2,8 @@
 
   /* UNBUILD */
   function USE(arg, req){
-    return req? require(arg) : arg.slice? USE[R(arg)] : function(mod, path){
+    var $req = require;
+    return req? $req(arg) : arg.slice? USE[R(arg)] : function(mod, path){
       arg(mod = {exports: {}});
       USE[R(path)] = mod.exports;
     }

--- a/sea.js
+++ b/sea.js
@@ -2,7 +2,8 @@
 
   /* UNBUILD */
   function USE(arg, req){
-    return req? require(arg) : arg.slice? USE[R(arg)] : function(mod, path){
+    var $req = require;
+    return req? $req(arg) : arg.slice? USE[R(arg)] : function(mod, path){
       arg(mod = {exports: {}});
       USE[R(path)] = mod.exports;
     }


### PR DESCRIPTION
expo/react-native does not like the use of `require(var)`  so the work around is to re name it