### PR TITLE
Update STUN servers

### DIFF
--- a/lib/webrtc.js
+++ b/lib/webrtc.js
@@ -21,7 +21,8 @@
 		opt.RTCIceCandidate = rtcic;
 		opt.rtc = opt.rtc || {'iceServers': [
       {urls: 'stun:stun.l.google.com:19302'},
-      {urls: "stun:stun.sipgate.net:3478"}/*,
+      {urls: 'stun:stun.cloudflare.com:3478'}/*,
+      {urls: "stun:stun.sipgate.net:3478"},
       {urls: "stun:stun.stunprotocol.org"},
       {urls: "stun:stun.sipgate.net:10000"},
       {urls: "stun:217.10.68.152:10000"},


### PR DESCRIPTION
#### Why this PR?
After some testing, I discovered that the reason the WebRTC connection failed frequently for me was because the sipgate.net STUN server would fail with [code 701](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/icecandidateerror_event#description).
I commented out the sipgate.net STUN server and added the Cloudflare STUN server.

##### Why Cloudflare?
I chose the Cloudflare STUN server because it is free to use and stable.

#### Changes:
Commented out sipgate.net STUN server.
Added Cloudflare STUN server.