### PR TITLE
Check put before get get next

### DIFF
--- a/gun.js
+++ b/gun.js
@@ -1547,7 +1547,7 @@
 			if(tmp = ((tmp = lex['#'])||'')['='] || tmp){ return gun.get(tmp) }
 			(tmp = gun.chain()._).lex = lex; // LEX!
 			gun.on('in', function(eve){
-				if(String.match(eve.get|| (eve.put||'')['.'], lex['.'] || lex['#'] || lex)){
+				if(String.match((eve.put||'')['.'] || eve.get, lex['.'] || lex['#'] || lex)){
 					tmp.on('in', eve);
 				}
 				this.to.next(eve);

--- a/src/map.js
+++ b/src/map.js
@@ -6,7 +6,7 @@ Gun.chain.get.next = function(gun, lex){ var tmp;
 	if(tmp = ((tmp = lex['#'])||'')['='] || tmp){ return gun.get(tmp) }
 	(tmp = gun.chain()._).lex = lex; // LEX!
 	gun.on('in', function(eve){
-		if(String.match(eve.get|| (eve.put||'')['.'], lex['.'] || lex['#'] || lex)){
+		if(String.match((eve.put||'')['.'] || eve.get, lex['.'] || lex['#'] || lex)){
 			tmp.on('in', eve);
 		}
 		this.to.next(eve);


### PR DESCRIPTION
When get is chained, `eve.put['.']` contains the lex match and `eve.get` contains the parent get, so need to match `put` first. Given the following example this matches `alice` instead of `friends`:

```
(async () => {

var alice = await SEA.pair();

const gun = Gun();

await gun.user().auth(alice);
    
let userNode = gun.user().get('friends');
userNode.put({
  "alice": {
    parent: false
  },
  "bob": {
    parent: false
  },
  "carol": {
    parent: false
  },
});

setTimeout(() => {
  gun.user().get('friends').get({'.': {'>': 'aaron', '<': 'ben'}}).once().map().once(console.log);
}, 2000);

})();
```