### PR TITLE
remove redundant return statement

### DIFF
--- a/gun.js
+++ b/gun.js
@@ -1215,7 +1215,7 @@
 			return;
 			//tmp.echo[cat.id] = {}; // TODO: Warning: This unsubscribes ALL of this chain's listeners from this link, not just the one callback event.
 			//obj.del(map, at); // TODO: Warning: This unsubscribes ALL of this chain's listeners from this link, not just the one callback event.
-			return;
+			//return;
 		}
 		var empty = {}, valid = Gun.valid, u;
 	})(USE, './get');

--- a/gun.js
+++ b/gun.js
@@ -1212,10 +1212,9 @@
 			//if(!map || !(tmp = map[at]) || !(tmp = tmp.at)){ return }
 			if(tmp = (seen = this.seen || (this.seen = {}))[at]){ return true }
 			seen[at] = true;
-			return;
 			//tmp.echo[cat.id] = {}; // TODO: Warning: This unsubscribes ALL of this chain's listeners from this link, not just the one callback event.
 			//obj.del(map, at); // TODO: Warning: This unsubscribes ALL of this chain's listeners from this link, not just the one callback event.
-			//return;
+			return;
 		}
 		var empty = {}, valid = Gun.valid, u;
 	})(USE, './get');


### PR DESCRIPTION
This removes some of the warnings in the firefox browser console saying "unreachable code after return"