### PR TITLE
Bound SEA auth retry counts

### DIFF
--- a/sea.js
+++ b/sea.js
@@ -970,7 +970,10 @@
       var pass = (alias || (pair && !(pair.priv && pair.epriv))) && typeof args[1] === 'string' ? args[1] : null;
       var cb = args.filter(arg => typeof arg === 'function')[0] || null; // cb now can stand anywhere, after alias/pass or pair
       var opt = args && args.length > 1 && typeof args[args.length-1] === 'object' ? args[args.length-1] : {}; // opt is always the last parameter which typeof === 'object' and stands after cb
-      var retries = typeof opt.retries === 'number' ? opt.retries : 9;
+      var retries = 9;
+      if(typeof opt.retries === 'number' && isFinite(opt.retries)){
+        retries = Math.max(0, Math.floor(opt.retries));
+      }
 
       var gun = this, cat = (gun._), root = gun.back(-1);
       

--- a/sea/auth.js
+++ b/sea/auth.js
@@ -8,7 +8,10 @@
       var pass = (alias || (pair && !(pair.priv && pair.epriv))) && typeof args[1] === 'string' ? args[1] : null;
       var cb = args.filter(arg => typeof arg === 'function')[0] || null; // cb now can stand anywhere, after alias/pass or pair
       var opt = args && args.length > 1 && typeof args[args.length-1] === 'object' ? args[args.length-1] : {}; // opt is always the last parameter which typeof === 'object' and stands after cb
-      var retries = typeof opt.retries === 'number' ? opt.retries : 9;
+      var retries = 9;
+      if(typeof opt.retries === 'number' && isFinite(opt.retries)){
+        retries = Math.max(0, Math.floor(opt.retries));
+      }
 
       var gun = this, cat = (gun._), root = gun.back(-1);
       

--- a/test/sea/sea.js
+++ b/test/sea/sea.js
@@ -331,6 +331,30 @@ describe('SEA', function(){
       })
     })
 
+    describe('auth retry bounds', function(){
+      [
+        {name: 'default', retries: undefined},
+        {name: 'zero', retries: 0},
+        {name: 'one', retries: 1},
+        {name: 'negative', retries: -1},
+        {name: 'fractional', retries: 0.5},
+        {name: 'infinite', retries: Infinity}
+      ].forEach(function(test){
+        it('finishes for '+test.name+' retries', function(done){
+          this.timeout(1500);
+          var retryGun = Gun({file: false});
+          var timer = setTimeout(function(){
+            done(new Error('auth did not finish for '+test.name+' retries'));
+          }, 1000);
+          retryGun.user().auth('missing-'+test.name, 'testing123', function(ack){
+            clearTimeout(timer);
+            expect(ack.err).to.be.ok();
+            done();
+          }, {retries: test.retries});
+        });
+      });
+    });
+
     it('logout, login via {pub}', function(done){
       var pub = user.is.pub;
       user.leave();

--- a/test/sea/sea.js
+++ b/test/sea/sea.js
@@ -341,13 +341,9 @@ describe('SEA', function(){
         {name: 'infinite', retries: Infinity}
       ].forEach(function(test){
         it('finishes for '+test.name+' retries', function(done){
-          this.timeout(1500);
+          this.timeout(5000);
           var retryGun = Gun({file: false});
-          var timer = setTimeout(function(){
-            done(new Error('auth did not finish for '+test.name+' retries'));
-          }, 1000);
           retryGun.user().auth('missing-'+test.name, 'testing123', function(ack){
-            clearTimeout(timer);
             expect(ack.err).to.be.ok();
             done();
           }, {retries: test.retries});
@@ -798,4 +794,3 @@ describe('SEA', function(){
 })
 
 }());
-


### PR DESCRIPTION
## Summary
- normalize SEA auth retry counts to finite non-negative integers
- preserve the default retry budget and retries=0 behavior
- add regression coverage for default, zero, one, negative, fractional, and infinite values

## Validation
- `node --check sea.js`
- `node --check sea/auth.js`
- `node --check test/sea/sea.js`
- direct auth control-flow smoke test: all six cases completed with an error callback
- `npm run testsea -- --grep "auth retry bounds"` could not start because `mocha` is not installed in the environment