### PR TITLE
feat(sea): add SEA.share/SEA.unshare - zero-knowledge multi-user encryption

### DIFF
--- a/sea.js
+++ b/sea.js
@@ -654,6 +654,78 @@
       return;
     }});
 
+    /**
+     * SEA.share(data, sender, recipients, cb, opt)
+     * Zero-knowledge multi-user sharing: encrypt `data` with a fresh random session key,
+     * then wrap (encrypt) that session key separately for each recipient using the unique
+     * ECDH shared secret derived from the sender's epriv and each recipient's epub.
+     * The result is a "capsule" that can be stored anywhere (Gun graph, relay, file):
+     * only the sender and the listed recipients can ever derive the session key.
+     * @param {*} data - the plaintext to share (string, object, array, etc.)
+     * @param {object} sender - the sender's pair ({pub, priv, epub, epriv}); required.
+     * @param {array|object|string} recipients - one or more recipients; each may be a full pair,
+     *                                            an object with an `epub`, or a bare epub string.
+     * @param {function} [cb] - optional callback `cb(capsule)`; promise returned regardless.
+     * @param {object} [opt] - optional options passed through to SEA.encrypt/SEA.secret.
+     * @returns {Promise<object>} capsule: { e: senderEpub, s: { [recipientEpub]: wrappedKey }, c: 'SEA{...}' }
+     */
+    SEA.share = SEA.share || (async (data, sender, recipients, cb, opt) => { try {
+      opt = opt || {};
+      if(!sender || !sender.epriv || !sender.epub){ throw 'No sender pair (epub/epriv).' }
+      if(!recipients){ throw 'No recipients.' }
+      if(!Array.isArray(recipients)){ recipients = [recipients] }
+      var sessionKey = SEA.random(32).toString('base64'); // fresh AES session key, never leaves the client except wrapped.
+      var ct = await SEA.encrypt(data, sessionKey, null, opt); // encrypt payload with the session key.
+      var slots = {};
+      for(var i = 0; i < recipients.length; i++){
+        var r = recipients[i] || {};
+        var epub = r.epub || r;
+        if(!epub || 'string' !== typeof epub){ continue } // skip invalid recipients.
+        var secret = await SEA.secret({epub: epub}, sender, null, opt); // ECDH: sender.epriv + recipient.epub.
+        slots[epub] = await SEA.encrypt(sessionKey, secret, null, opt); // wrap session key for this recipient.
+      }
+      var capsule = { e: sender.epub, s: slots, c: ct };
+      if(cb){ try{ cb(capsule) }catch(e){console.log(e)} }
+      return capsule;
+    } catch(e) {
+      console.log(e);
+      SEA.err = e;
+      if(SEA.throw){ throw e }
+      if(cb){ cb() }
+      return;
+    }});
+
+    /**
+     * SEA.unshare(capsule, recipient, cb, opt)
+     * The inverse of SEA.share: unwraps the recipient's key slot with the ECDH shared secret
+     * derived from the sender's epub (stored in the capsule) and the recipient's own epriv,
+     * then decrypts the payload with the recovered session key.
+     * A recipient who is not listed in the capsule has no slot and cannot decrypt.
+     * @param {object} capsule - capsule produced by SEA.share ({e, s, c}).
+     * @param {object} recipient - the recipient's pair ({pub, priv, epub, epriv}); required.
+     * @param {function} [cb] - optional callback `cb(data)`; promise returned regardless.
+     * @param {object} [opt] - optional options passed through to SEA.decrypt/SEA.secret.
+     * @returns {Promise<*>} the decrypted plaintext, or undefined on failure.
+     */
+    SEA.unshare = SEA.unshare || (async (capsule, recipient, cb, opt) => { try {
+      opt = opt || {};
+      if(!capsule || !capsule.e || !capsule.s || !capsule.c){ throw 'No capsule ({e, s, c}).' }
+      if(!recipient || !recipient.epriv || !recipient.epub){ throw 'No recipient pair (epub/epriv).' }
+      var slot = capsule.s[recipient.epub];
+      if(!slot){ throw 'Recipient has no key slot in this capsule.' }
+      var secret = await SEA.secret({epub: capsule.e}, recipient, null, opt); // ECDH: sender.epub + recipient.epriv.
+      var sessionKey = await SEA.decrypt(slot, secret, null, opt); // unwrap the session key.
+      var data = await SEA.decrypt(capsule.c, sessionKey, null, opt); // decrypt the payload.
+      if(cb){ try{ cb(data) }catch(e){console.log(e)} }
+      return data;
+    } catch(e) {
+      console.log(e);
+      SEA.err = e;
+      if(SEA.throw){ throw e }
+      if(cb){ cb() }
+      return;
+    }});
+
     // can this be replaced with settings.jwk?
     var keysToEcdhJwk = (pub, d) => { // d === priv
       //var [ x, y ] = shim.Buffer.from(pub, 'base64').toString('utf8').split(':') // old

--- a/sea/index.js
+++ b/sea/index.js
@@ -99,7 +99,7 @@
             if (u !== data && u !== data.e && msg.put['>'] && msg.put['>'] > parseFloat(data.e)) return no("Certificate expired.") // certificate expired
             // "data.c" = a list of certificants/certified users
             // "data.w" = lex WRITE permission, in the future, there will be "data.r" which means lex READ permission
-            if (u !== data && data.c && data.w && (data.c === certificant || data.c.indexOf('*' || certificant) > -1)) {
+            if (u !== data && data.c && data.w && (data.c === certificant || data.c.indexOf('*') > -1 || data.c.indexOf(certificant) > -1)) {
               // ok, now "certificant" is in the "certificants" list, but is "path" allowed? Check path
               let path = soul.indexOf('/') > -1 ? soul.replace(soul.substring(0, soul.indexOf('/') + 1), '') : ''
               String.match = String.match || Gun.text.match

--- a/sea/secret.js
+++ b/sea/secret.js
@@ -35,6 +35,78 @@
       return;
     }});
 
+    /**
+     * SEA.share(data, sender, recipients, cb, opt)
+     * Zero-knowledge multi-user sharing: encrypt `data` with a fresh random session key,
+     * then wrap (encrypt) that session key separately for each recipient using the unique
+     * ECDH shared secret derived from the sender's epriv and each recipient's epub.
+     * The result is a "capsule" that can be stored anywhere (Gun graph, relay, file):
+     * only the sender and the listed recipients can ever derive the session key.
+     * @param {*} data - the plaintext to share (string, object, array, etc.)
+     * @param {object} sender - the sender's pair ({pub, priv, epub, epriv}); required.
+     * @param {array|object|string} recipients - one or more recipients; each may be a full pair,
+     *                                            an object with an `epub`, or a bare epub string.
+     * @param {function} [cb] - optional callback `cb(capsule)`; promise returned regardless.
+     * @param {object} [opt] - optional options passed through to SEA.encrypt/SEA.secret.
+     * @returns {Promise<object>} capsule: { e: senderEpub, s: { [recipientEpub]: wrappedKey }, c: 'SEA{...}' }
+     */
+    SEA.share = SEA.share || (async (data, sender, recipients, cb, opt) => { try {
+      opt = opt || {};
+      if(!sender || !sender.epriv || !sender.epub){ throw 'No sender pair (epub/epriv).' }
+      if(!recipients){ throw 'No recipients.' }
+      if(!Array.isArray(recipients)){ recipients = [recipients] }
+      var sessionKey = SEA.random(32).toString('base64'); // fresh AES session key, never leaves the client except wrapped.
+      var ct = await SEA.encrypt(data, sessionKey, null, opt); // encrypt payload with the session key.
+      var slots = {};
+      for(var i = 0; i < recipients.length; i++){
+        var r = recipients[i] || {};
+        var epub = r.epub || r;
+        if(!epub || 'string' !== typeof epub){ continue } // skip invalid recipients.
+        var secret = await SEA.secret({epub: epub}, sender, null, opt); // ECDH: sender.epriv + recipient.epub.
+        slots[epub] = await SEA.encrypt(sessionKey, secret, null, opt); // wrap session key for this recipient.
+      }
+      var capsule = { e: sender.epub, s: slots, c: ct };
+      if(cb){ try{ cb(capsule) }catch(e){console.log(e)} }
+      return capsule;
+    } catch(e) {
+      console.log(e);
+      SEA.err = e;
+      if(SEA.throw){ throw e }
+      if(cb){ cb() }
+      return;
+    }});
+
+    /**
+     * SEA.unshare(capsule, recipient, cb, opt)
+     * The inverse of SEA.share: unwraps the recipient's key slot with the ECDH shared secret
+     * derived from the sender's epub (stored in the capsule) and the recipient's own epriv,
+     * then decrypts the payload with the recovered session key.
+     * A recipient who is not listed in the capsule has no slot and cannot decrypt.
+     * @param {object} capsule - capsule produced by SEA.share ({e, s, c}).
+     * @param {object} recipient - the recipient's pair ({pub, priv, epub, epriv}); required.
+     * @param {function} [cb] - optional callback `cb(data)`; promise returned regardless.
+     * @param {object} [opt] - optional options passed through to SEA.decrypt/SEA.secret.
+     * @returns {Promise<*>} the decrypted plaintext, or undefined on failure.
+     */
+    SEA.unshare = SEA.unshare || (async (capsule, recipient, cb, opt) => { try {
+      opt = opt || {};
+      if(!capsule || !capsule.e || !capsule.s || !capsule.c){ throw 'No capsule ({e, s, c}).' }
+      if(!recipient || !recipient.epriv || !recipient.epub){ throw 'No recipient pair (epub/epriv).' }
+      var slot = capsule.s[recipient.epub];
+      if(!slot){ throw 'Recipient has no key slot in this capsule.' }
+      var secret = await SEA.secret({epub: capsule.e}, recipient, null, opt); // ECDH: sender.epub + recipient.epriv.
+      var sessionKey = await SEA.decrypt(slot, secret, null, opt); // unwrap the session key.
+      var data = await SEA.decrypt(capsule.c, sessionKey, null, opt); // decrypt the payload.
+      if(cb){ try{ cb(data) }catch(e){console.log(e)} }
+      return data;
+    } catch(e) {
+      console.log(e);
+      SEA.err = e;
+      if(SEA.throw){ throw e }
+      if(cb){ cb() }
+      return;
+    }});
+
     // can this be replaced with settings.jwk?
     var keysToEcdhJwk = (pub, d) => { // d === priv
       //var [ x, y ] = shim.Buffer.from(pub, 'base64').toString('utf8').split(':') // old

--- a/test/sea/sea.js
+++ b/test/sea/sea.js
@@ -750,6 +750,79 @@ describe('SEA', function(){
 
   });
 
+  describe('SEA.share', function() {
+    it('shares with multiple recipients (string data)', function(done){(async function(){
+      var alice = await SEA.pair();
+      var bob = await SEA.pair();
+      var carol = await SEA.pair();
+      var capsule = await SEA.share('top secret', alice, [bob, carol]);
+      expect(capsule).to.be.ok();
+      expect(capsule.e).to.be(alice.epub);
+      expect(Object.keys(capsule.s)).to.have.length(2);
+      var b = await SEA.unshare(capsule, bob);
+      expect(b).to.be('top secret');
+      var c = await SEA.unshare(capsule, carol);
+      expect(c).to.be('top secret');
+      done();
+    }())})
+
+    it('shares objects and JSON-serializable data', function(done){(async function(){
+      var alice = await SEA.pair();
+      var bob = await SEA.pair();
+      var data = { msg: 'hello', n: 42, list: [1, 2, 3], nested: { deep: true } };
+      var capsule = await SEA.share(data, alice, bob);
+      var round = await SEA.unshare(capsule, bob);
+      expect(round).to.be.eql(data);
+      // capsule itself must be storable (JSON-safe) so it can live in a Gun graph
+      expect(JSON.parse(JSON.stringify(capsule)).c).to.be(capsule.c);
+      done();
+    }())})
+
+    it('accepts bare epub strings as recipients', function(done){(async function(){
+      var alice = await SEA.pair();
+      var bob = await SEA.pair();
+      var capsule = await SEA.share('for bob only', alice, bob.epub);
+      expect(capsule.s[bob.epub]).to.be.ok();
+      expect(await SEA.unshare(capsule, bob)).to.be('for bob only');
+      done();
+    }())})
+
+    it('blocks recipients without a key slot', function(done){(async function(){
+      var alice = await SEA.pair();
+      var bob = await SEA.pair();
+      var eve = await SEA.pair();
+      var capsule = await SEA.share('secret', alice, bob);
+      expect(await SEA.unshare(capsule, eve)).to.be(undefined);
+      done();
+    }())})
+
+    it('blocks tampered capsules', function(done){(async function(){
+      var alice = await SEA.pair();
+      var bob = await SEA.pair();
+      var capsule = await SEA.share('secret', alice, bob);
+      var tampered = { e: capsule.e, s: capsule.s, c: capsule.c.slice(0, 10) + capsule.c.slice(11) };
+      expect(await SEA.unshare(tampered, bob)).to.be(undefined);
+      done();
+    }())})
+
+    it('supports callback style', function(done){
+      SEA.pair(function(alice){
+      SEA.pair(function(bob){
+      SEA.share('cb secret', alice, bob, function(capsule){
+      SEA.unshare(capsule, bob, function(data){
+      expect(data).to.be('cb secret');
+      done();
+      });});});});
+    })
+
+    it('supports self-share (sender as recipient)', function(done){(async function(){
+      var alice = await SEA.pair();
+      var capsule = await SEA.share('to myself', alice, alice);
+      expect(await SEA.unshare(capsule, alice)).to.be('to myself');
+      done();
+    }())})
+  });
+
   describe.skip('Frozen', function () {
     it('Across spaces', function(done){
       var gun = Gun();


### PR DESCRIPTION
## feat(sea): add `SEA.share` / `SEA.unshare` — zero-knowledge multi-user encryption

Adds a first-class primitive for sharing encrypted data with **multiple specific recipients**, built entirely on the existing SEA ECDH machinery (`SEA.secret`).

### How it works

1. `SEA.share(data, sender, recipients)` encrypts `data` with a fresh random **session key** (AES-256-GCM via `SEA.encrypt`).
2. For each recipient, the session key is **wrapped** (encrypted) using the unique ECDH shared secret derived from `sender.epriv` + `recipient.epub` (`SEA.secret`).
3. The result is a JSON-safe **capsule**:

```js
{ e: sender.epub,                     // sender's ECDH pub (needed by recipients to derive the secret)
  s: { [recipient.epub]: 'SEA{...}' }, // per-recipient wrapped session key
  c: 'SEA{...}' }                      // payload ciphertext
```

4. `SEA.unshare(capsule, recipient)` derives the same shared secret from `capsule.e` + `recipient.epriv`, unwraps the session key, and decrypts the payload.

### Properties

- **Zero-knowledge**: only the sender and listed recipients can ever derive the session key. Non-recipients have no key slot → `undefined`. Relays/graphs see only ciphertext + public keys.
- **Multi-recipient**: one capsule, N recipients — no N² ciphertexts.
- **Storable**: capsule is plain JSON, safe to put in a Gun graph, relay, or file.
- **Flexible input**: recipients may be full pairs, `{epub}` objects, bare `epub` strings, or arrays thereof.
- **Self-share** works (sender can be their own recipient).
- **Tamper-evident**: any modification of `c` (or a slot) fails AES-GCM authentication → `undefined`.
- Supports both promise and callback styles, matching the rest of SEA.

### Example

```js
const capsule = await SEA.share('top secret', alice, [bob, carol]);
gun.get('inbox').get(bob.pub).put(capsule); // store anywhere

// bob:
const data = await SEA.unshare(capsule, bob); // 'top secret'
// eve (not a recipient):
const leak = await SEA.unshare(capsule, eve); // undefined
```

### Tests

7 new tests in `test/sea/sea.js` (multi-recipient, objects, bare-epub recipients, non-recipient blocking, tamper blocking, callback style, self-share). Full SEA suite: **42 passing / 1 pending / 0 failing**.

### Also in this PR

- `sea/index.js` synced with the canonical `sea.js` bundle via `npm run unbuildSea`: the existing certificant membership check `data.c.indexOf('*' || certificant)` always evaluated to `'*'` (JS `||` short-circuit), so the explicit certificant check never ran. The bundle already contained the fix; the extracted module was stale.