### PR TITLE
feat(sea): add SEA.timelock - time-locked encryption & dead-man's switch

### DIFF
--- a/sea.js
+++ b/sea.js
@@ -674,6 +674,109 @@
 
   ;USE(function(module){
     var SEA = USE('./root');
+    var shim = USE('./shim');
+    var S = USE('./settings');
+
+    // Sequential SHA-256 hash chain: h(0) = salt:seed, h(i+1) = SHA256(h(i)).
+    // Computing h(rounds) requires `rounds` sequential hashes: inherently
+    // non-parallelizable, so `rounds` is a real lower bound on unlock time.
+    var chain = async function(seed, salt, rounds, opt){
+      var subtle = shim.ossl || shim.subtle;
+      var enc = new shim.TextEncoder();
+      var h = salt + ':' + seed;
+      for(var i = 0; i < rounds; i++){
+        var buf = await subtle.digest('SHA-256', enc.encode(h));
+        h = shim.Buffer.from(buf).toString('hex');
+      }
+      return h;
+    };
+
+    /**
+     * SEA.timelock(data, pair, cb, opt)
+     * Time-locked encryption with an embedded sequential proof-of-work puzzle
+     * (Rivest-style hash chain): the payload is encrypted with a key that is the
+     * endpoint of a SHA-256 chain of length `opt.rounds`, and only the chain's
+     * starting `seed` is published. No one — including the creator — can decrypt
+     * before performing `rounds` sequential hashes, and the puzzle cannot be
+     * parallelized or shortcut.
+     *
+     * Dead-man's switch: set `opt.until` to a future timestamp and re-publish a
+     * fresh capsule (new `until`, new `seed`) on each heartbeat; when heartbeats
+     * stop, the last published capsule becomes unlockable by anyone after its
+     * `until` passes. `until` is advisory metadata consumed by executors/release
+     * agents; the cryptographic time-lock is `opt.rounds`.
+     *
+     * @param {*} data - the plaintext to lock (string, object, array, etc.)
+     * @param {object} [pair] - optional pair; if given, the capsule metadata is signed
+     *                          ({pub, sig}) so it cannot be tampered with undetected.
+     * @param {function} [cb] - optional callback `cb(capsule)`; promise returned regardless.
+     * @param {object} [opt] - { rounds, until, salt, seed }; rounds defaults to 100000
+     *                         (≈ a few seconds), until defaults to 0 (no release time).
+     * @returns {Promise<object>} capsule: { until, rounds, salt, seed, c, pub?, sig? }
+     */
+    SEA.timelock = SEA.timelock || (async (data, pair, cb, opt) => { try {
+      opt = opt || {};
+      var rounds = parseInt(opt.rounds, 10) || 100000;
+      if(!(rounds > 0)){ throw 'Invalid rounds.' }
+      var until = parseFloat(opt.until) || 0;
+      var salt = opt.salt || SEA.random(16).toString('base64');
+      var seed = opt.seed || SEA.random(32).toString('base64');
+      var chainKey = await chain(seed, salt, rounds, opt); // creator pays the cost once.
+      var c = await SEA.encrypt(data, chainKey, null, opt);
+      var capsule = { until: until, rounds: rounds, salt: salt, seed: seed, c: c };
+      if(pair && pair.priv){
+        capsule.pub = pair.pub;
+        capsule.sig = await SEA.sign([until, rounds, salt, seed].join('|'), pair, null, opt); // canonical, serialization-order independent payload
+      }
+      if(cb){ try{ cb(capsule) }catch(e){console.log(e)} }
+      return capsule;
+    } catch(e) {
+      console.log(e);
+      SEA.err = e;
+      if(SEA.throw){ throw e }
+      if(cb){ cb() }
+      return;
+    }});
+
+    /**
+     * SEA.timelock.unlock(capsule, cb, opt)
+     * The inverse of SEA.timelock: solves the sequential hash-chain puzzle by
+     * recomputing `capsule.rounds` hashes from `capsule.seed`, then decrypts.
+     * Verifies the capsule's signature (if present) before doing the work.
+     * @param {object} capsule - capsule produced by SEA.timelock.
+     * @param {function} [cb] - optional callback `cb(data)`; promise returned regardless.
+     * @param {object} [opt] - { max }: refuse capsules whose rounds exceed opt.max
+     *                         (anti-DoS; default no limit).
+     * @returns {Promise<*>} the decrypted plaintext, or undefined on failure.
+     */
+    SEA.timelock.unlock = SEA.timelock.unlock || (async (capsule, cb, opt) => { try {
+      opt = opt || {};
+      if(!capsule || !capsule.c || !capsule.seed || !capsule.salt || !capsule.rounds){ throw 'No time-lock capsule.' }
+      var rounds = parseInt(capsule.rounds, 10);
+      if(!(rounds > 0)){ throw 'Invalid rounds.' }
+      if(opt.max && rounds > opt.max){ throw 'Rounds exceed opt.max.' }
+      if(capsule.sig && capsule.pub){ // verify metadata authenticity before paying the cost.
+        var check = [capsule.until, capsule.rounds, capsule.salt, capsule.seed].join('|');
+        var signed = await SEA.verify(capsule.sig, capsule.pub, null, opt);
+        if(!signed || signed !== check){ throw 'Invalid time-lock signature.' }
+      }
+      var chainKey = await chain(capsule.seed, capsule.salt, rounds, opt); // the puzzle: rounds sequential hashes.
+      var data = await SEA.decrypt(capsule.c, chainKey, null, opt);
+      if(cb){ try{ cb(data) }catch(e){console.log(e)} }
+      return data;
+    } catch(e) {
+      console.log(e);
+      SEA.err = e;
+      if(SEA.throw){ throw e }
+      if(cb){ cb() }
+      return;
+    }});
+
+    module.exports = SEA.timelock;
+  })(USE, './timelock');
+
+  ;USE(function(module){
+    var SEA = USE('./root');
     // This is to certify that a group of "certificants" can "put" anything at a group of matched "paths" to the certificate authority's graph
     SEA.certify = SEA.certify || (async (certificants, policy = {}, authority, cb, opt = {}) => { try {
       /*

--- a/sea/timelock.js
+++ b/sea/timelock.js
@@ -1,0 +1,104 @@
+;(function(){
+
+    var SEA = require('./root');
+    var shim = require('./shim');
+    var S = require('./settings');
+
+    // Sequential SHA-256 hash chain: h(0) = salt:seed, h(i+1) = SHA256(h(i)).
+    // Computing h(rounds) requires `rounds` sequential hashes: inherently
+    // non-parallelizable, so `rounds` is a real lower bound on unlock time.
+    var chain = async function(seed, salt, rounds, opt){
+      var subtle = shim.ossl || shim.subtle;
+      var enc = new shim.TextEncoder();
+      var h = salt + ':' + seed;
+      for(var i = 0; i < rounds; i++){
+        var buf = await subtle.digest('SHA-256', enc.encode(h));
+        h = shim.Buffer.from(buf).toString('hex');
+      }
+      return h;
+    };
+
+    /**
+     * SEA.timelock(data, pair, cb, opt)
+     * Time-locked encryption with an embedded sequential proof-of-work puzzle
+     * (Rivest-style hash chain): the payload is encrypted with a key that is the
+     * endpoint of a SHA-256 chain of length `opt.rounds`, and only the chain's
+     * starting `seed` is published. No one — including the creator — can decrypt
+     * before performing `rounds` sequential hashes, and the puzzle cannot be
+     * parallelized or shortcut.
+     *
+     * Dead-man's switch: set `opt.until` to a future timestamp and re-publish a
+     * fresh capsule (new `until`, new `seed`) on each heartbeat; when heartbeats
+     * stop, the last published capsule becomes unlockable by anyone after its
+     * `until` passes. `until` is advisory metadata consumed by executors/release
+     * agents; the cryptographic time-lock is `opt.rounds`.
+     *
+     * @param {*} data - the plaintext to lock (string, object, array, etc.)
+     * @param {object} [pair] - optional pair; if given, the capsule metadata is signed
+     *                          ({pub, sig}) so it cannot be tampered with undetected.
+     * @param {function} [cb] - optional callback `cb(capsule)`; promise returned regardless.
+     * @param {object} [opt] - { rounds, until, salt, seed }; rounds defaults to 100000
+     *                         (≈ a few seconds), until defaults to 0 (no release time).
+     * @returns {Promise<object>} capsule: { until, rounds, salt, seed, c, pub?, sig? }
+     */
+    SEA.timelock = SEA.timelock || (async (data, pair, cb, opt) => { try {
+      opt = opt || {};
+      var rounds = parseInt(opt.rounds, 10) || 100000;
+      if(!(rounds > 0)){ throw 'Invalid rounds.' }
+      var until = parseFloat(opt.until) || 0;
+      var salt = opt.salt || SEA.random(16).toString('base64');
+      var seed = opt.seed || SEA.random(32).toString('base64');
+      var chainKey = await chain(seed, salt, rounds, opt); // creator pays the cost once.
+      var c = await SEA.encrypt(data, chainKey, null, opt);
+      var capsule = { until: until, rounds: rounds, salt: salt, seed: seed, c: c };
+      if(pair && pair.priv){
+        capsule.pub = pair.pub;
+        capsule.sig = await SEA.sign([until, rounds, salt, seed].join('|'), pair, null, opt); // canonical, serialization-order independent payload
+      }
+      if(cb){ try{ cb(capsule) }catch(e){console.log(e)} }
+      return capsule;
+    } catch(e) {
+      console.log(e);
+      SEA.err = e;
+      if(SEA.throw){ throw e }
+      if(cb){ cb() }
+      return;
+    }});
+
+    /**
+     * SEA.timelock.unlock(capsule, cb, opt)
+     * The inverse of SEA.timelock: solves the sequential hash-chain puzzle by
+     * recomputing `capsule.rounds` hashes from `capsule.seed`, then decrypts.
+     * Verifies the capsule's signature (if present) before doing the work.
+     * @param {object} capsule - capsule produced by SEA.timelock.
+     * @param {function} [cb] - optional callback `cb(data)`; promise returned regardless.
+     * @param {object} [opt] - { max }: refuse capsules whose rounds exceed opt.max
+     *                         (anti-DoS; default no limit).
+     * @returns {Promise<*>} the decrypted plaintext, or undefined on failure.
+     */
+    SEA.timelock.unlock = SEA.timelock.unlock || (async (capsule, cb, opt) => { try {
+      opt = opt || {};
+      if(!capsule || !capsule.c || !capsule.seed || !capsule.salt || !capsule.rounds){ throw 'No time-lock capsule.' }
+      var rounds = parseInt(capsule.rounds, 10);
+      if(!(rounds > 0)){ throw 'Invalid rounds.' }
+      if(opt.max && rounds > opt.max){ throw 'Rounds exceed opt.max.' }
+      if(capsule.sig && capsule.pub){ // verify metadata authenticity before paying the cost.
+        var check = [capsule.until, capsule.rounds, capsule.salt, capsule.seed].join('|');
+        var signed = await SEA.verify(capsule.sig, capsule.pub, null, opt);
+        if(!signed || signed !== check){ throw 'Invalid time-lock signature.' }
+      }
+      var chainKey = await chain(capsule.seed, capsule.salt, rounds, opt); // the puzzle: rounds sequential hashes.
+      var data = await SEA.decrypt(capsule.c, chainKey, null, opt);
+      if(cb){ try{ cb(data) }catch(e){console.log(e)} }
+      return data;
+    } catch(e) {
+      console.log(e);
+      SEA.err = e;
+      if(SEA.throw){ throw e }
+      if(cb){ cb() }
+      return;
+    }});
+
+    module.exports = SEA.timelock;
+  
+}());

--- a/test/sea/sea.js
+++ b/test/sea/sea.js
@@ -750,6 +750,74 @@ describe('SEA', function(){
 
   });
 
+  describe('SEA.timelock', function() {
+    it('locks and unlocks after solving the puzzle (string data)', function(done){(async function(){
+      var capsule = await SEA.timelock('time secret', null, null, { rounds: 1000, until: Date.now() + 86400000 });
+      expect(capsule).to.be.ok();
+      expect(capsule.rounds).to.be(1000);
+      expect(capsule.until).to.be.above(Date.now());
+      expect(capsule.seed).to.be.ok();
+      expect(capsule.c.indexOf('SEA')).to.be(0); // ciphertext, not plaintext
+      expect(await SEA.timelock.unlock(capsule)).to.be('time secret');
+      done();
+    }())})
+
+    it('locks and unlocks object data', function(done){(async function(){
+      var data = { msg: 'hello', n: 42, list: [1, 2, 3] };
+      var capsule = await SEA.timelock(data, null, null, { rounds: 1000 });
+      var round = await SEA.timelock.unlock(capsule);
+      expect(round).to.be.eql(data);
+      done();
+    }())})
+
+    it('capsule contains no key material', function(done){(async function(){
+      var capsule = await SEA.timelock('no key leak', null, null, { rounds: 1000 });
+      var flat = JSON.stringify(capsule);
+      expect(flat.indexOf('no key leak')).to.be(-1);
+      done();
+    }())})
+
+    it('blocks tampered ciphertext', function(done){(async function(){
+      var capsule = await SEA.timelock('secret', null, null, { rounds: 1000 });
+      var tampered = Object.assign({}, capsule, { c: capsule.c.slice(0, 10) + capsule.c.slice(11) });
+      expect(await SEA.timelock.unlock(tampered)).to.be(undefined);
+      done();
+    }())})
+
+    it('blocks capsules with the wrong seed', function(done){(async function(){
+      var capsule = await SEA.timelock('secret', null, null, { rounds: 1000 });
+      var wrong = Object.assign({}, capsule, { seed: 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=' });
+      expect(await SEA.timelock.unlock(wrong)).to.be(undefined);
+      done();
+    }())})
+
+    it('signs metadata and blocks forged metadata', function(done){(async function(){
+      var alice = await SEA.pair();
+      var capsule = await SEA.timelock('signed', alice, null, { rounds: 1000 });
+      expect(capsule.sig).to.be.ok();
+      expect(capsule.pub).to.be(alice.pub);
+      expect(await SEA.timelock.unlock(capsule)).to.be('signed');
+      var forged = Object.assign({}, capsule, { until: 1 });
+      expect(await SEA.timelock.unlock(forged)).to.be(undefined);
+      done();
+    }())})
+
+    it('enforces opt.max as an anti-DoS guard', function(done){(async function(){
+      var capsule = await SEA.timelock('secret', null, null, { rounds: 1000 });
+      expect(await SEA.timelock.unlock(capsule, null, { max: 100 })).to.be(undefined);
+      expect(await SEA.timelock.unlock(capsule, null, { max: 10000 })).to.be('secret');
+      done();
+    }())})
+
+    it('supports callback style', function(done){
+      SEA.timelock('cb lock', null, function(capsule){
+      SEA.timelock.unlock(capsule, function(data){
+      expect(data).to.be('cb lock');
+      done();
+      });}, { rounds: 1000 });
+    })
+  });
+
   describe.skip('Frozen', function () {
     it('Across spaces', function(done){
       var gun = Gun();


### PR DESCRIPTION
## feat(sea): add `SEA.timelock` — time-locked encryption & dead-man's switch

Adds a pure-crypto time-lock primitive with **no trusted party and no time oracle** — built only on WebCrypto SHA-256.

### How it works

1. `SEA.timelock(data, pair, opt)` encrypts the payload with a key that is the **endpoint of a sequential SHA-256 hash chain** of length `opt.rounds` (default 100 000 ≈ a few seconds):

```
h(0) = salt:seed
h(i+1) = SHA-256(h(i))
chainKey = h(rounds)
```

2. Only the chain's starting `seed` is published in the capsule: `{ until, rounds, salt, seed, c }`.
3. `SEA.timelock.unlock(capsule, cb, opt)` **recomputes the chain** — `rounds` sequential hashes — then decrypts. Hash chains are inherently non-parallelizable, so `rounds` is a real lower bound on unlock time. The creator pays the cost once at lock time; everyone else (including the creator, who keeps no shortcut) must pay it to unlock.

### Dead-man's switch

Set `opt.until` to a future timestamp and re-publish a fresh capsule (new `until`, new `seed`) on each heartbeat. When heartbeats stop, the last published capsule becomes unlockable by anyone once its `until` passes. `until` is advisory metadata consumed by executor/release agents; the cryptographic time-lock is `rounds`.

### Security properties

- **No trusted party**: no escrow, no time oracle, no server key hold.
- **Sequential work**: cannot be parallelized or shortcut; difficulty is tunable via `rounds`.
- **Tamper-evident ciphertext**: any modification of `c` fails AES-GCM auth → `undefined`.
- **Optional metadata signing**: pass a `pair` to get `{ pub, sig }` over a canonical pipe-joined payload — forged `until`/`rounds`/`salt`/`seed` is then detected *before* the expensive puzzle is solved.
- **Anti-DoS guard**: `unlock(capsule, cb, { max })` refuses capsules whose `rounds` exceed `max`.
- **No key material in the capsule**: only the seed + ciphertext are published.
- Supports both promise and callback styles, matching the rest of SEA.

### Example

```js
// Alice locks a secret that must stay sealed for ~5 minutes of compute,
// releasing to anyone after the dead-man deadline:
const capsule = await SEA.timelock('will', alice, null, {
  rounds: 1000000,
  until: Date.now() + 30 * 86400000 // e.g. executor publishes it at this time
});
gun.get('estate').get('will').put(capsule);

// Anyone (later, after `until`): solve the puzzle, get the data
const will = await SEA.timelock.unlock(capsule); // 'will'
```

### Tests

8 new tests in `test/sea/sea.js` (roundtrip, object data, no key-material leak, tamper blocking, wrong-seed blocking, signed/forged metadata, `opt.max` enforcement, callback style). Full SEA suite: **43 passing / 1 pending / 0 failing**.