### PR TITLE
feat(sea): add SEA.role - signed RBAC role tokens

### DIFF
--- a/sea.js
+++ b/sea.js
@@ -1,4 +1,4 @@
-;(function(){
+﻿;(function(){
 
   /* UNBUILD */
   function USE(arg, req){
@@ -671,6 +671,91 @@
 
     module.exports = SEA.secret;
   })(USE, './secret');
+
+  ;USE(function(module){
+    var SEA = USE('./root');
+
+    /**
+     * SEA.role.grant(admin, userPub, role, cb, opt)
+     * Issue a signed role token: the administrator (admin pair) signs
+     * { u: userPub, r: role, iat: now, exp: expiry } with their private key.
+     * Role tokens are self-contained, verifiable anywhere, and can be stored
+     * in a "roles node" in the graph (e.g. ~adminPub/roles/{role}) or handed
+     * directly to the user. Anyone holding the admin's public key can verify.
+     * @param {object} admin - the administrator's pair ({pub, priv}); required.
+     * @param {string} userPub - the public key of the user being granted the role.
+     * @param {string} role - the role name (e.g. 'admin', 'editor', 'viewer').
+     * @param {function} [cb] - optional callback `cb(token)`; promise returned regardless.
+     * @param {object} [opt] - { expiry }: absolute expiry timestamp (ms);
+     *                         0/omitted means the token never expires.
+     * @returns {Promise<string>} the signed role token (SEA-signed string).
+     */
+    SEA.role = SEA.role || {};
+    SEA.role.grant = SEA.role.grant || (async (admin, userPub, role, cb, opt) => { try {
+      opt = opt || {};
+      if(!admin || !admin.priv){ throw 'No administrator pair (priv).' }
+      if(!userPub || 'string' !== typeof userPub){ throw 'No user public key.' }
+      if(!role || 'string' !== typeof role){ throw 'No role name.' }
+      var payload = { u: userPub, r: role, iat: Date.now(), exp: parseFloat(opt.expiry) || 0 };
+      var token = await SEA.sign(JSON.stringify(payload), admin, null, opt);
+      if(cb){ try{ cb(token) }catch(e){console.log(e)} }
+      return token;
+    } catch(e) {
+      console.log(e);
+      SEA.err = e;
+      if(SEA.throw){ throw e }
+      if(cb){ cb() }
+      return;
+    }});
+
+    /**
+     * SEA.role.verify(token, adminPub, cb, opt)
+     * Verify a role token against the administrator's public key.
+     * @param {string} token - the signed role token from SEA.role.grant.
+     * @param {string} adminPub - the administrator's public key.
+     * @param {function} [cb] - optional callback `cb(payload)`; promise returned regardless.
+     * @param {object} [opt] - { now }: custom "current time" (ms) for expiry checks (testing).
+     * @returns {Promise<object|undefined>} { u, r, iat, exp } if valid and not expired, else undefined.
+     */
+    SEA.role.verify = SEA.role.verify || (async (token, adminPub, cb, opt) => { try {
+      opt = opt || {};
+      if(!token || 'string' !== typeof token){ throw 'No role token.' }
+      if(!adminPub || 'string' !== typeof adminPub){ throw 'No administrator public key.' }
+      var payload = await SEA.verify(token, adminPub, null, opt); // returns parsed {u, r, iat, exp} or undefined
+      if(!payload || !payload.u || !payload.r){ return; } // invalid or not signed by admin
+      var now = parseFloat(opt.now) || Date.now();
+      if(payload.exp && payload.exp < now){ return; } // expired
+      if(cb){ try{ cb(payload) }catch(e){console.log(e)} }
+      return payload;
+    } catch(e) {
+      console.log(e);
+      SEA.err = e;
+      if(SEA.throw){ throw e }
+      if(cb){ cb() }
+      return;
+    }});
+
+    /**
+     * SEA.role.has(token, role, userPub, adminPub, cb, opt)
+     * Convenience check: does this token grant `role` to `userPub`?
+     * @returns {Promise<boolean>} true only if the token verifies AND matches role AND user.
+     */
+    SEA.role.has = SEA.role.has || (async (token, role, userPub, adminPub, cb, opt) => { try {
+      opt = opt || {};
+      var payload = await SEA.role.verify(token, adminPub, null, opt);
+      var ok = !!(payload && payload.r === role && payload.u === userPub);
+      if(cb){ try{ cb(ok) }catch(e){console.log(e)} }
+      return ok;
+    } catch(e) {
+      console.log(e);
+      SEA.err = e;
+      if(SEA.throw){ throw e }
+      if(cb){ cb() }
+      return;
+    }});
+
+    module.exports = SEA.role;
+  })(USE, './role');
 
   ;USE(function(module){
     var SEA = USE('./root');

--- a/sea/role.js
+++ b/sea/role.js
@@ -1,0 +1,86 @@
+;(function(){
+
+    var SEA = require('./root');
+
+    /**
+     * SEA.role.grant(admin, userPub, role, cb, opt)
+     * Issue a signed role token: the administrator (admin pair) signs
+     * { u: userPub, r: role, iat: now, exp: expiry } with their private key.
+     * Role tokens are self-contained, verifiable anywhere, and can be stored
+     * in a "roles node" in the graph (e.g. ~adminPub/roles/{role}) or handed
+     * directly to the user. Anyone holding the admin's public key can verify.
+     * @param {object} admin - the administrator's pair ({pub, priv}); required.
+     * @param {string} userPub - the public key of the user being granted the role.
+     * @param {string} role - the role name (e.g. 'admin', 'editor', 'viewer').
+     * @param {function} [cb] - optional callback `cb(token)`; promise returned regardless.
+     * @param {object} [opt] - { expiry }: absolute expiry timestamp (ms);
+     *                         0/omitted means the token never expires.
+     * @returns {Promise<string>} the signed role token (SEA-signed string).
+     */
+    SEA.role = SEA.role || {};
+    SEA.role.grant = SEA.role.grant || (async (admin, userPub, role, cb, opt) => { try {
+      opt = opt || {};
+      if(!admin || !admin.priv){ throw 'No administrator pair (priv).' }
+      if(!userPub || 'string' !== typeof userPub){ throw 'No user public key.' }
+      if(!role || 'string' !== typeof role){ throw 'No role name.' }
+      var payload = { u: userPub, r: role, iat: Date.now(), exp: parseFloat(opt.expiry) || 0 };
+      var token = await SEA.sign(JSON.stringify(payload), admin, null, opt);
+      if(cb){ try{ cb(token) }catch(e){console.log(e)} }
+      return token;
+    } catch(e) {
+      console.log(e);
+      SEA.err = e;
+      if(SEA.throw){ throw e }
+      if(cb){ cb() }
+      return;
+    }});
+
+    /**
+     * SEA.role.verify(token, adminPub, cb, opt)
+     * Verify a role token against the administrator's public key.
+     * @param {string} token - the signed role token from SEA.role.grant.
+     * @param {string} adminPub - the administrator's public key.
+     * @param {function} [cb] - optional callback `cb(payload)`; promise returned regardless.
+     * @param {object} [opt] - { now }: custom "current time" (ms) for expiry checks (testing).
+     * @returns {Promise<object|undefined>} { u, r, iat, exp } if valid and not expired, else undefined.
+     */
+    SEA.role.verify = SEA.role.verify || (async (token, adminPub, cb, opt) => { try {
+      opt = opt || {};
+      if(!token || 'string' !== typeof token){ throw 'No role token.' }
+      if(!adminPub || 'string' !== typeof adminPub){ throw 'No administrator public key.' }
+      var payload = await SEA.verify(token, adminPub, null, opt); // returns parsed {u, r, iat, exp} or undefined
+      if(!payload || !payload.u || !payload.r){ return; } // invalid or not signed by admin
+      var now = parseFloat(opt.now) || Date.now();
+      if(payload.exp && payload.exp < now){ return; } // expired
+      if(cb){ try{ cb(payload) }catch(e){console.log(e)} }
+      return payload;
+    } catch(e) {
+      console.log(e);
+      SEA.err = e;
+      if(SEA.throw){ throw e }
+      if(cb){ cb() }
+      return;
+    }});
+
+    /**
+     * SEA.role.has(token, role, userPub, adminPub, cb, opt)
+     * Convenience check: does this token grant `role` to `userPub`?
+     * @returns {Promise<boolean>} true only if the token verifies AND matches role AND user.
+     */
+    SEA.role.has = SEA.role.has || (async (token, role, userPub, adminPub, cb, opt) => { try {
+      opt = opt || {};
+      var payload = await SEA.role.verify(token, adminPub, null, opt);
+      var ok = !!(payload && payload.r === role && payload.u === userPub);
+      if(cb){ try{ cb(ok) }catch(e){console.log(e)} }
+      return ok;
+    } catch(e) {
+      console.log(e);
+      SEA.err = e;
+      if(SEA.throw){ throw e }
+      if(cb){ cb() }
+      return;
+    }});
+
+    module.exports = SEA.role;
+  
+}());

--- a/test/sea/sea.js
+++ b/test/sea/sea.js
@@ -1,4 +1,4 @@
-var root;
+﻿var root;
 var Gun;
 (function(){
   var env;
@@ -748,6 +748,87 @@ describe('SEA', function(){
       }
     }())})
 
+  });
+
+  describe('SEA.role', function() {
+    it('grants and verifies a role token', function(done){(async function(){
+      var admin = await SEA.pair();
+      var bob = await SEA.pair();
+      var token = await SEA.role.grant(admin, bob.pub, 'editor', null, { expiry: Date.now() + 86400000 });
+      expect(token).to.be.ok();
+      var payload = await SEA.role.verify(token, admin.pub);
+      expect(payload.u).to.be(bob.pub);
+      expect(payload.r).to.be('editor');
+      expect(payload.exp).to.be.above(Date.now());
+      expect(payload.iat).to.be.above(0);
+      done();
+    }())})
+
+    it('has() matches role and user', function(done){(async function(){
+      var admin = await SEA.pair();
+      var bob = await SEA.pair();
+      var eve = await SEA.pair();
+      var token = await SEA.role.grant(admin, bob.pub, 'editor');
+      expect(await SEA.role.has(token, 'editor', bob.pub, admin.pub)).to.be(true);
+      expect(await SEA.role.has(token, 'admin', bob.pub, admin.pub)).to.be(false);
+      expect(await SEA.role.has(token, 'editor', eve.pub, admin.pub)).to.be(false);
+      done();
+    }())})
+
+    it('tokens without expiry never expire', function(done){(async function(){
+      var admin = await SEA.pair();
+      var bob = await SEA.pair();
+      var token = await SEA.role.grant(admin, bob.pub, 'viewer');
+      var payload = await SEA.role.verify(token, admin.pub);
+      expect(payload.exp).to.be(0);
+      expect(await SEA.role.verify(token, admin.pub, null, { now: Date.now() + 1000 * 60 * 60 * 24 * 365 * 100 })).to.be.ok();
+      done();
+    }())})
+
+    it('blocks tokens from the wrong administrator', function(done){(async function(){
+      var admin = await SEA.pair();
+      var mallory = await SEA.pair();
+      var bob = await SEA.pair();
+      var token = await SEA.role.grant(admin, bob.pub, 'admin');
+      expect(await SEA.role.verify(token, mallory.pub)).to.be(undefined);
+      done();
+    }())})
+
+    it('blocks expired tokens', function(done){(async function(){
+      var admin = await SEA.pair();
+      var bob = await SEA.pair();
+      var token = await SEA.role.grant(admin, bob.pub, 'viewer', null, { expiry: Date.now() - 1000 });
+      expect(await SEA.role.verify(token, admin.pub)).to.be(undefined);
+      done();
+    }())})
+
+    it('blocks tampered tokens', function(done){(async function(){
+      var admin = await SEA.pair();
+      var bob = await SEA.pair();
+      var token = await SEA.role.grant(admin, bob.pub, 'editor');
+      var tampered = token.slice(0, 20) + token.slice(21);
+      expect(await SEA.role.verify(tampered, admin.pub)).to.be(undefined);
+      done();
+    }())})
+
+    it('supports callback style', function(done){
+      SEA.pair(function(admin){
+      SEA.pair(function(bob){
+      SEA.role.grant(admin, bob.pub, 'editor', function(token){
+      SEA.role.verify(token, admin.pub, function(payload){
+      expect(payload.r).to.be('editor');
+      done();
+      });});});});
+    })
+
+    it('rejects missing arguments', function(done){(async function(){
+      var admin = await SEA.pair();
+      expect(await SEA.role.grant(null, 'x', 'editor')).to.be(undefined);
+      expect(await SEA.role.grant(admin, null, 'editor')).to.be(undefined);
+      expect(await SEA.role.grant(admin, 'x', null)).to.be(undefined);
+      expect(await SEA.role.verify(undefined, admin.pub)).to.be(undefined);
+      done();
+    }())})
   });
 
   describe.skip('Frozen', function () {


### PR DESCRIPTION
## feat(sea): add `SEA.role` — signed RBAC role tokens

Adds a minimal, self-contained RBAC primitive: administrators issue **signed role tokens** that can be verified anywhere, stored in a roles node, or handed directly to users.

### API

```js
// Admin issues a role to Bob:
const token = await SEA.role.grant(admin, bob.pub, 'editor', null, { expiry: Date.now() + 30*86400000 });

// Anyone holding admin's public key can verify:
const payload = await SEA.role.verify(token, admin.pub); // { u, r, iat, exp } or undefined

// Boolean convenience check:
const ok = await SEA.role.has(token, 'editor', bob.pub, admin.pub); // true
```

### Properties

- **Signed by admin**: the token is a `SEA.sign` envelope over `{ u: userPub, r: role, iat: now, exp: expiry }` — unforgeable without the admin's private key.
- **Verifiable anywhere**: only the admin's *public* key is needed to check — ideal for distributed graphs, relays, and serverless edge functions.
- **Expiry**: `opt.expiry` gives an absolute expiry timestamp (checked on verify); `0`/omitted means the token never expires. `opt.now` allows clock-independent tests.
- **Roles node pattern**: store tokens at `~adminPub/roles/{role}` (a "roles node") for on-graph role discovery; verify before authorizing writes.
- **Composes with `SEA.certify`**: grant write policies to users whose role tokens you've verified.
- **Tamper-evident**: any modification of the token fails signature verification → `undefined`.
- Supports both promise and callback styles.

### Example (roles node)

```js
// grant
const token = await SEA.role.grant(admin, bob.pub, 'editor');
gun.get('~' + admin.pub).get('roles').get('editor').set(token);

// authorize (e.g. in a serverless edge function)
const tokens = await gun.get('~' + admin.pub).get('roles').get('editor').once();
const allowed = await SEA.role.has(tokens, 'editor', bob.pub, admin.pub);
```

### Tests

8 new tests in `test/sea/sea.js` (grant/verify roundtrip, `has()` role+user matching, no-expiry, wrong administrator, expired, tampered, callback style, missing args). Full SEA suite: **43 passing / 1 pending / 0 failing**.