### PR TITLE
SEA: preserve raw strings with decrypt skipParse option

### DIFF
--- a/sea.js
+++ b/sea.js
@@ -604,7 +604,8 @@
           return await SEA.decrypt(data, pair, cb, opt);
         }
       }
-      var r = await S.parse(new shim.TextDecoder('utf8').decode(ct));
+      var raw = new shim.TextDecoder('utf8').decode(ct);
+      var r = opt.skipParse ? raw : await S.parse(raw);
       if(cb){ try{ cb(r) }catch(e){console.log(e)} }
       return r;
     } catch(e) { 

--- a/sea/decrypt.js
+++ b/sea/decrypt.js
@@ -28,7 +28,8 @@
           return await SEA.decrypt(data, pair, cb, opt);
         }
       }
-      var r = await S.parse(new shim.TextDecoder('utf8').decode(ct));
+      var raw = new shim.TextDecoder('utf8').decode(ct);
+      var r = opt.skipParse ? raw : await S.parse(raw);
       if(cb){ try{ cb(r) }catch(e){console.log(e)} }
       return r;
     } catch(e) { 

--- a/test/sea/sea.js
+++ b/test/sea/sea.js
@@ -187,6 +187,23 @@ describe('SEA', function(){
       });});});});});});});});});});});});});});});});});});});});});});});});});});});
     })
     
+    it('decrypt skipParse preserves string payloads', async function(){
+      var pair = await SEA.pair();
+      var values = [
+        '[hello there]',
+        '{"a":1}',
+        'true',
+        '1',
+        '[]'
+      ];
+
+      for(var i = 0; i < values.length; i++){
+        var enc = await SEA.encrypt(values[i], pair);
+        var dec = await SEA.decrypt(enc, pair, null, {skipParse: true});
+        expect(dec).to.be(values[i]);
+      }
+    })
+
     /*it('DOESNT DECRYPT SCIENTIFIC NOTATION', function(done){
       var pair, s, v;
       SEA.pair(function(pair){

--- a/types/sea/ISEA.d.ts
+++ b/types/sea/ISEA.d.ts
@@ -134,7 +134,9 @@ export interface ISEA {
    */
   decrypt<T extends unknown = any>(
     message: string,
-    pair: { epriv: string }
+    pair: { epriv: string },
+    callback?: ((data: T | undefined) => void) | null,
+    options?: { skipParse?: boolean }
   ): Promise<T>;
 
   /**
@@ -145,7 +147,9 @@ export interface ISEA {
    */
   decrypt<T extends unknown = any>(
     message: string,
-    passphrase: string
+    passphrase: string,
+    callback?: ((data: T | undefined) => void) | null,
+    options?: { skipParse?: boolean }
   ): Promise<T>;
 
   /**


### PR DESCRIPTION
## What changed

Adds an opt-in `skipParse` option to `SEA.decrypt` so callers can recover plaintext strings exactly as encrypted, even when the string happens to look like JSON.

The default behavior is unchanged for backwards compatibility: decrypted plaintext still passes through `SEA.opt.parse` unless `skipParse` is explicitly enabled.

Example:

```js
const enc = await SEA.encrypt('[hello there]', pair);
const dec = await SEA.decrypt(enc, pair, null, { skipParse: true });
// dec === '[hello there]'
```

This updates both the canonical `sea.js` bundle and extracted `sea/decrypt.js`, exposes the callback/options arguments in the TypeScript declarations, and adds regression coverage for JSON-looking string payloads.

Fixes #1418.

## Validation

- `npm run testsea`: 36 passing, 1 pending, including the new `skipParse` regression.
- `test/sea/nodeauth.js`: all 5 visible scenarios passed on the first clean run. The harness intentionally calls `process.exit(-1)` in its `after` hook, so it exits with status 255 after the tests.
- `git diff --check`: clean.
